### PR TITLE
Refactor/parsers and models for readability

### DIFF
--- a/lib/src/exceptions/musicxml_parse_exception.dart
+++ b/lib/src/exceptions/musicxml_parse_exception.dart
@@ -1,4 +1,4 @@
-import 'package:musicxml_parser/src/exceptions/invalid_musicxml_exception.dart';
+import 'package:musicxml_parser/musicxml_parser.dart';
 
 /// Exception thrown when parsing MusicXML content fails.
 ///

--- a/lib/src/models/credit.dart
+++ b/lib/src/models/credit.dart
@@ -42,7 +42,8 @@ class Credit {
     final parts = <String>[];
     if (page != null) parts.add('page: $page');
     if (creditType != null) parts.add('creditType: "$creditType"');
-    if (creditWords.isNotEmpty) parts.add('creditWords: ${creditWords.map((w) => '"$w"').join(', ')}');
+    if (creditWords.isNotEmpty)
+      parts.add('creditWords: ${creditWords.map((w) => '"$w"').join(', ')}');
 
     return 'Credit{${parts.join(', ')}}';
   }

--- a/lib/src/models/ending.dart
+++ b/lib/src/models/ending.dart
@@ -34,17 +34,15 @@ class Ending {
           printObject == other.printObject;
 
   @override
-  int get hashCode =>
-      number.hashCode ^
-      type.hashCode ^
-      printObject.hashCode;
+  int get hashCode => number.hashCode ^ type.hashCode ^ printObject.hashCode;
 
   @override
   String toString() {
     final parts = [
       'number: $number',
       'type: $type',
-      if (printObject != "yes") 'printObject: $printObject', // Only show if not default
+      if (printObject != "yes")
+        'printObject: $printObject', // Only show if not default
     ];
     return 'Ending{${parts.join(', ')}}';
   }

--- a/lib/src/models/key_signature.dart
+++ b/lib/src/models/key_signature.dart
@@ -1,18 +1,31 @@
 import 'package:meta/meta.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_structure_exception.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_validation_exception.dart';
+import 'package:musicxml_parser/src/parser/xml_helper.dart';
 import 'package:musicxml_parser/src/utils/validation_utils.dart';
+import 'package:xml/xml.dart';
 
 /// Represents a key signature in a musical score.
+///
+/// A key signature is defined by the number of sharps or flats (fifths)
+/// and an optional mode (e.g., major, minor).
+///
+/// Objects of this class are immutable.
 @immutable
 class KeySignature {
-  /// The number of sharps (positive) or flats (negative) in the key signature.
+  /// The number of sharps (positive value) or flats (negative value)
+  /// in the key signature. Typically ranges from -7 to 7.
   final int fifths;
 
-  /// The mode of the key signature (major, minor, etc.).
+  /// The mode of the key signature (e.g., "major", "minor", "dorian").
+  ///
+  /// This is optional as per MusicXML specification.
   final String? mode;
 
   /// Creates a new [KeySignature] instance.
   ///
-  /// The [fifths] value should be between -7 and +7.
+  /// It's recommended to use [KeySignature.validated] or [KeySignature.fromXmlElement]
+  /// for creating instances, as they include validation.
   const KeySignature({
     required this.fifths,
     this.mode,
@@ -20,8 +33,16 @@ class KeySignature {
 
   /// Creates a new [KeySignature] instance with validation.
   ///
-  /// This factory constructor performs validation and throws
-  /// [MusicXmlValidationException] if the key signature is invalid.
+  /// This factory constructor performs validation against MusicXML rules
+  /// (e.g., fifths within range, valid mode if specified).
+  ///
+  /// Throws [MusicXmlValidationException] if the key signature is invalid.
+  ///
+  /// Parameters:
+  ///   [fifths]: The number of sharps or flats.
+  ///   [mode]: The mode of the key (optional).
+  ///   [line]: The line number in the XML document (for context in error messages).
+  ///   [context]: Additional context for error messages.
   factory KeySignature.validated({
     required int fifths,
     String? mode,
@@ -29,10 +50,68 @@ class KeySignature {
     Map<String, dynamic>? context,
   }) {
     final keySignature = KeySignature(fifths: fifths, mode: mode);
+    // ValidationUtils.validateKeySignature will throw if invalid.
     ValidationUtils.validateKeySignature(keySignature,
         line: line, context: context);
     return keySignature;
   }
+
+  /// Creates a new [KeySignature] instance from a MusicXML `<key>` [element].
+  ///
+  /// This factory parses the required `<fifths>` element and the optional
+  /// `<mode>` element. It then validates the parsed values.
+  ///
+  /// Throws [MusicXmlStructureException] if required XML elements are missing.
+  /// Throws [MusicXmlValidationException] if the parsed values are invalid.
+  ///
+  /// Parameters:
+  ///   [element]: The XML element representing the `<key>`.
+  ///   [partId]: The ID of the part (for context in error messages).
+  ///   [measureNumber]: The number of the measure (for context in error messages).
+  factory KeySignature.fromXmlElement(
+    XmlElement element,
+    String partId,
+    String measureNumber,
+  ) {
+    final line = XmlHelper.getLineNumber(element);
+
+    final fifthsElement = element.findElements('fifths').firstOrNull;
+    if (fifthsElement == null) {
+      throw MusicXmlStructureException(
+        'Required <fifths> element not found in <key>',
+        parentElement: 'key',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber},
+      );
+    }
+    final fifthsText = fifthsElement.innerText.trim();
+    final fifths = int.tryParse(fifthsText);
+
+    if (fifths == null) {
+      throw MusicXmlValidationException(
+        'Invalid key signature fifths value: "$fifthsText". Must be an integer.',
+        rule: 'key_fifths_invalid',
+        line: XmlHelper.getLineNumber(fifthsElement),
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'parsedFifths': fifthsText
+        },
+      );
+    }
+
+    final modeElement = element.findElements('mode').firstOrNull;
+    final mode = modeElement?.innerText.trim();
+
+    // Use the .validated factory to ensure consistent validation logic
+    return KeySignature.validated(
+      fifths: fifths,
+      mode: mode,
+      line: line,
+      context: {'part': partId, 'measure': measureNumber},
+    );
+  }
+
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/models/key_signature.dart
+++ b/lib/src/models/key_signature.dart
@@ -112,7 +112,6 @@ class KeySignature {
     );
   }
 
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/src/models/measure.dart
+++ b/lib/src/models/measure.dart
@@ -85,7 +85,8 @@ class Measure {
           const DeepCollectionEquality().equals(beams, other.beams) &&
           const DeepCollectionEquality().equals(barlines, other.barlines) &&
           ending == other.ending &&
-          const DeepCollectionEquality().equals(wordsDirections, other.wordsDirections) &&
+          const DeepCollectionEquality()
+              .equals(wordsDirections, other.wordsDirections) &&
           printObject == other.printObject;
 
   @override
@@ -151,6 +152,7 @@ class MeasureBuilder {
 
   /// Line number in the XML for error reporting context.
   final int? _line;
+
   /// Additional context for error reporting.
   final Map<String, dynamic>? _context;
 
@@ -265,9 +267,9 @@ class MeasureBuilder {
     // MusicXML allows non-integer measure numbers (e.g., "X1" for pickup, "1a").
     // For simplicity, this example just checks for empty or obviously invalid.
     if (_number.isEmpty) {
-        // This might be an appropriate place to throw MusicXmlValidationException
-        // or log a warning, depending on desired strictness.
-        // For now, relying on parser to ensure number is present.
+      // This might be an appropriate place to throw MusicXmlValidationException
+      // or log a warning, depending on desired strictness.
+      // For now, relying on parser to ensure number is present.
     }
 
     return Measure(

--- a/lib/src/models/measure.dart
+++ b/lib/src/models/measure.dart
@@ -1,51 +1,63 @@
 import 'package:meta/meta.dart';
 import 'package:collection/collection.dart'; // For DeepCollectionEquality
-import 'package:musicxml_parser/src/models/barline.dart'; // Import for Barline
+import 'package:musicxml_parser/src/models/barline.dart';
 import 'package:musicxml_parser/src/models/beam.dart';
-import 'package:musicxml_parser/src/models/ending.dart'; // Import for Ending
+import 'package:musicxml_parser/src/models/ending.dart';
 import 'package:musicxml_parser/src/models/key_signature.dart';
 import 'package:musicxml_parser/src/models/note.dart';
 import 'package:musicxml_parser/src/models/time_signature.dart';
 import 'package:musicxml_parser/src/models/direction_words.dart';
-import 'print_object.dart'; // New import
+import 'print_object.dart';
 
-/// Represents a measure in a musical score.
+/// Represents a single measure in a musical score.
+///
+/// A measure contains a sequence of [notes], and can also define attributes
+/// like [keySignature], [timeSignature], [barlines], and [width].
+/// It is identified by a [number] (measure number).
+///
+/// Instances are typically created via [MeasureBuilder].
+/// Objects of this class are immutable.
 @immutable
 class Measure {
-  /// The measure number.
+  /// The measure number as a string (e.g., "1", "2a").
   final String number;
 
-  /// The notes contained in the measure.
+  /// The list of [Note] objects contained within this measure.
   final List<Note> notes;
 
-  /// The key signature of the measure, if specified.
+  /// The key signature active at the beginning of this measure, if specified.
   final KeySignature? keySignature;
 
-  /// The time signature of the measure, if specified.
+  /// The time signature active at the beginning of this measure, if specified.
   final TimeSignature? timeSignature;
 
-  /// The width of the measure in tenths.
+  /// The visual width of the measure in tenths.
   final double? width;
 
-  /// The beams contained in the measure.
+  /// A list of [Beam] objects defined within this measure.
   final List<Beam> beams;
 
-  /// Whether the measure is a pickup measure.
+  /// Indicates if this measure is a pickup (anacrusis) measure.
   final bool isPickup;
 
-  /// A list of barlines associated with this measure.
+  /// A list of [Barline] objects associated with this measure (e.g., start, end, repeat).
   final List<Barline>? barlines;
 
-  /// Optional repeat ending information for this measure.
+  /// Repeat [Ending] information for this measure, if applicable.
   final Ending? ending;
 
-  /// Textual directions (e.g., "Allegro", "Fine") associated with this measure.
+  /// List of textual [WordsDirection] (e.g., "Allegro", "Fine") associated with this measure.
   final List<WordsDirection> wordsDirections;
 
-  /// Print-related information for this measure (e.g. new page/system, local layouts).
+  /// Print-related hints and overrides for this measure, such as new page/system breaks
+  /// or local layout changes.
   final PrintObject? printObject;
 
   /// Creates a new [Measure] instance.
+  ///
+  /// It is generally recommended to use [MeasureBuilder] for constructing [Measure]
+  /// objects, as it simplifies the process of incrementally adding properties
+  /// during parsing.
   const Measure({
     required this.number,
     required this.notes,
@@ -57,7 +69,7 @@ class Measure {
     this.barlines,
     this.ending,
     this.wordsDirections = const [],
-    this.printObject, // New parameter
+    this.printObject,
   });
 
   @override
@@ -74,7 +86,7 @@ class Measure {
           const DeepCollectionEquality().equals(barlines, other.barlines) &&
           ending == other.ending &&
           const DeepCollectionEquality().equals(wordsDirections, other.wordsDirections) &&
-          printObject == other.printObject; // Add to equality check
+          printObject == other.printObject;
 
   @override
   int get hashCode =>
@@ -87,7 +99,7 @@ class Measure {
       (barlines != null ? const DeepCollectionEquality().hash(barlines!) : 0) ^
       (ending?.hashCode ?? 0) ^
       const DeepCollectionEquality().hash(wordsDirections) ^
-      printObject.hashCode; // Add to hash code
+      (printObject?.hashCode ?? 0);
 
   @override
   String toString() {
@@ -102,8 +114,174 @@ class Measure {
       if (barlines != null && barlines!.isNotEmpty) 'barlines: $barlines',
       if (ending != null) 'ending: $ending',
       if (wordsDirections.isNotEmpty) 'wordsDirections: $wordsDirections',
-      if (printObject != null) 'printObject: $printObject', // Add to toString
+      if (printObject != null) 'printObject: $printObject',
     ];
     return 'Measure{${parts.join(', ')}}';
+  }
+}
+
+/// Builder for creating [Measure] objects incrementally.
+///
+/// This builder is useful during the parsing process where measure properties
+/// (like notes, barlines, key/time signatures) are discovered and set step-by-step.
+/// The [build] method finalizes the measure construction.
+///
+/// Example:
+/// ```dart
+/// final measureBuilder = MeasureBuilder("1", line: 5, context: {'partId': 'P1'});
+/// measureBuilder
+///   .addNote(aNote)
+///   .setKeySignature(aKeySignature)
+///   .addBarline(aBarline);
+/// final Measure measure = measureBuilder.build();
+/// ```
+class MeasureBuilder {
+  /// The measure number.
+  final String _number;
+  List<Note> _notes = [];
+  KeySignature? _keySignature;
+  TimeSignature? _timeSignature;
+  double? _width;
+  List<Beam> _beams = [];
+  bool _isPickup = false;
+  List<Barline>? _barlines;
+  Ending? _ending;
+  List<WordsDirection> _wordsDirections = [];
+  PrintObject? _printObject;
+
+  /// Line number in the XML for error reporting context.
+  final int? _line;
+  /// Additional context for error reporting.
+  final Map<String, dynamic>? _context;
+
+  /// Creates a [MeasureBuilder] for a measure with the given [number].
+  ///
+  /// [line] and [context] can be provided for more detailed error
+  /// messages if validation fails (though MeasureBuilder currently doesn't
+  /// perform extensive validation itself, it would pass this to a
+  /// hypothetical `Measure.validated` factory).
+  MeasureBuilder(this._number, {int? line, Map<String, dynamic>? context})
+      : _line = line,
+        _context = context;
+
+  /// Sets all notes for the measure.
+  MeasureBuilder setNotes(List<Note> notes) {
+    _notes = notes;
+    return this;
+  }
+
+  /// Adds a single [Note] to the measure.
+  MeasureBuilder addNote(Note note) {
+    _notes.add(note);
+    return this;
+  }
+
+  /// Sets the key signature for the measure.
+  MeasureBuilder setKeySignature(KeySignature? keySignature) {
+    _keySignature = keySignature;
+    return this;
+  }
+
+  /// Sets the time signature for the measure.
+  MeasureBuilder setTimeSignature(TimeSignature? timeSignature) {
+    _timeSignature = timeSignature;
+    return this;
+  }
+
+  /// Sets the visual width of the measure.
+  MeasureBuilder setWidth(double? width) {
+    _width = width;
+    return this;
+  }
+
+  /// Sets all beams for the measure.
+  MeasureBuilder setBeams(List<Beam> beams) {
+    _beams = beams;
+    return this;
+  }
+
+  /// Adds a single [Beam] to the measure.
+  MeasureBuilder addBeam(Beam beam) {
+    _beams.add(beam);
+    return this;
+  }
+
+  /// Sets whether this is a pickup measure.
+  MeasureBuilder setIsPickup(bool isPickup) {
+    _isPickup = isPickup;
+    return this;
+  }
+
+  /// Sets all barlines for the measure.
+  MeasureBuilder setBarlines(List<Barline>? barlines) {
+    _barlines = barlines;
+    return this;
+  }
+
+  /// Adds a single [Barline] to the measure.
+  MeasureBuilder addBarline(Barline barline) {
+    _barlines ??= [];
+    _barlines!.add(barline);
+    return this;
+  }
+
+  /// Sets the repeat ending for the measure.
+  MeasureBuilder setEnding(Ending? ending) {
+    _ending = ending;
+    return this;
+  }
+
+  /// Sets all textual words directions for the measure.
+  MeasureBuilder setWordsDirections(List<WordsDirection> wordsDirections) {
+    _wordsDirections = wordsDirections;
+    return this;
+  }
+
+  /// Adds a single [WordsDirection] to the measure.
+  MeasureBuilder addWordsDirection(WordsDirection wordsDirection) {
+    _wordsDirections.add(wordsDirection);
+    return this;
+  }
+
+  /// Sets the print object containing layout hints for the measure.
+  MeasureBuilder setPrintObject(PrintObject? printObject) {
+    _printObject = printObject;
+    return this;
+  }
+
+  /// Temporary getter for MeasureParser to access notes count.
+  /// TODO: Re-evaluate if a local list in MeasureParser + setNotes on builder is cleaner.
+  @internal
+  int debugGetNotesCount() => _notes.length;
+
+  /// Builds the [Measure] instance.
+  ///
+  /// Currently, this method performs basic validation on the measure number.
+  /// More complex validation (e.g., sum of note durations matches time signature)
+  /// would typically be handled by a `Measure.validated` factory or a separate
+  /// validation step post-parsing.
+  Measure build() {
+    // Example of a basic validation that could be done here or in a static factory.
+    // MusicXML allows non-integer measure numbers (e.g., "X1" for pickup, "1a").
+    // For simplicity, this example just checks for empty or obviously invalid.
+    if (_number.isEmpty) {
+        // This might be an appropriate place to throw MusicXmlValidationException
+        // or log a warning, depending on desired strictness.
+        // For now, relying on parser to ensure number is present.
+    }
+
+    return Measure(
+      number: _number,
+      notes: _notes,
+      keySignature: _keySignature,
+      timeSignature: _timeSignature,
+      width: _width,
+      beams: _beams,
+      isPickup: _isPickup,
+      barlines: _barlines,
+      ending: _ending,
+      wordsDirections: _wordsDirections,
+      printObject: _printObject,
+    );
   }
 }

--- a/lib/src/models/note.dart
+++ b/lib/src/models/note.dart
@@ -177,7 +177,8 @@ class Note {
           dots == other.dots &&
           timeModification == other.timeModification &&
           const DeepCollectionEquality().equals(slurs, other.slurs) &&
-          const DeepCollectionEquality().equals(articulations, other.articulations) &&
+          const DeepCollectionEquality()
+              .equals(articulations, other.articulations) &&
           const DeepCollectionEquality().equals(ties, other.ties) &&
           isChordElementPresent == other.isChordElementPresent;
 
@@ -191,7 +192,9 @@ class Note {
       (dots?.hashCode ?? 0) ^
       (timeModification?.hashCode ?? 0) ^
       (slurs != null ? const DeepCollectionEquality().hash(slurs!) : 0) ^
-      (articulations != null ? const DeepCollectionEquality().hash(articulations!) : 0) ^
+      (articulations != null
+          ? const DeepCollectionEquality().hash(articulations!)
+          : 0) ^
       (ties != null ? const DeepCollectionEquality().hash(ties!) : 0) ^
       isChordElementPresent.hashCode;
 

--- a/lib/src/models/page_layout.dart
+++ b/lib/src/models/page_layout.dart
@@ -46,7 +46,8 @@ class PageMargins {
 class PageLayout {
   final double? pageHeight;
   final double? pageWidth;
-  final List<PageMargins> pageMargins; // Can have up to 2 (odd/even) or one for "both"
+  final List<PageMargins>
+      pageMargins; // Can have up to 2 (odd/even) or one for "both"
 
   const PageLayout({
     this.pageHeight,
@@ -54,7 +55,7 @@ class PageLayout {
     this.pageMargins = const [],
   });
 
-   @override
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PageLayout &&

--- a/lib/src/models/part.dart
+++ b/lib/src/models/part.dart
@@ -69,6 +69,7 @@ class PartBuilder {
 
   /// Line number in the XML for error reporting context.
   final int? _line;
+
   /// Additional context for error reporting.
   final Map<String, dynamic>? _context;
 
@@ -77,7 +78,8 @@ class PartBuilder {
   /// [line] and [context] can be provided for more detailed error
   /// messages if validation (not currently implemented in builder) were to fail.
   PartBuilder(this._id, {int? line, Map<String, dynamic>? context})
-   : _line = line, _context = context;
+      : _line = line,
+        _context = context;
 
   /// Sets the name of the part.
   PartBuilder setName(String? name) {

--- a/lib/src/models/part.dart
+++ b/lib/src/models/part.dart
@@ -1,19 +1,28 @@
 import 'package:meta/meta.dart';
 import 'package:musicxml_parser/src/models/measure.dart';
 
-/// Represents a part in a musical score.
+/// Represents a single part (e.g., a single instrument or voice) within a musical score.
+///
+/// A part consists of a unique [id], an optional [name], and a list of [measures]
+/// that make up the musical content of the part.
+///
+/// Instances are typically created via [PartBuilder].
+/// Objects of this class are immutable.
 @immutable
 class Part {
-  /// The part ID.
+  /// The unique identifier for this part within the score.
   final String id;
 
-  /// The part name.
+  /// The display name of the part (e.g., "Violin I", "Piano Left Hand").
   final String? name;
 
-  /// The measures contained in the part.
+  /// The list of [Measure] objects that constitute this part.
   final List<Measure> measures;
 
   /// Creates a new [Part] instance.
+  ///
+  /// It is generally recommended to use [PartBuilder] for constructing [Part]
+  /// objects, especially during parsing.
   const Part({
     required this.id,
     this.name,
@@ -27,6 +36,8 @@ class Part {
           runtimeType == other.runtimeType &&
           id == other.id &&
           name == other.name &&
+          // Note: DeepCollectionEquality might be needed for measures if deep comparison is critical
+          // For now, relying on list's default equality (identity or element-wise if elements override ==)
           measures == other.measures;
 
   @override
@@ -35,4 +46,72 @@ class Part {
   @override
   String toString() =>
       'Part{id: $id, name: $name, measures: ${measures.length}}';
+}
+
+/// Builder for creating [Part] objects incrementally.
+///
+/// This builder is useful during the parsing process for MusicXML `<part>` elements,
+/// allowing measures to be added one by one as they are parsed.
+/// The [build] method finalizes the part construction.
+///
+/// Example:
+/// ```dart
+/// final partBuilder = PartBuilder("P1", line: 20)..setName("Flute");
+/// partBuilder.addMeasure(firstMeasure);
+/// partBuilder.addMeasure(secondMeasure);
+/// final Part flutePart = partBuilder.build();
+/// ```
+class PartBuilder {
+  /// The ID of the part being built.
+  final String _id;
+  String? _name;
+  List<Measure> _measures = [];
+
+  /// Line number in the XML for error reporting context.
+  final int? _line;
+  /// Additional context for error reporting.
+  final Map<String, dynamic>? _context;
+
+  /// Creates a [PartBuilder] for a part with the given [id].
+  ///
+  /// [line] and [context] can be provided for more detailed error
+  /// messages if validation (not currently implemented in builder) were to fail.
+  PartBuilder(this._id, {int? line, Map<String, dynamic>? context})
+   : _line = line, _context = context;
+
+  /// Sets the name of the part.
+  PartBuilder setName(String? name) {
+    _name = name;
+    return this;
+  }
+
+  /// Sets all measures for the part.
+  PartBuilder setMeasures(List<Measure> measures) {
+    _measures = measures;
+    return this;
+  }
+
+  /// Adds a single [Measure] to the part.
+  PartBuilder addMeasure(Measure measure) {
+    _measures.add(measure);
+    return this;
+  }
+
+  /// Builds the [Part] instance.
+  ///
+  /// This method constructs the [Part] object from the properties set
+  /// on the builder. Currently, it performs minimal validation itself,
+  /// relying on the parser to ensure required fields like ID are present.
+  Part build() {
+    if (_id.isEmpty) {
+      // This should ideally be caught by the PartParser before even creating the builder
+      // but serves as a safeguard or location for future builder-specific validation.
+      throw ArgumentError('Part ID cannot be empty.');
+    }
+    return Part(
+      id: _id,
+      name: _name,
+      measures: _measures,
+    );
+  }
 }

--- a/lib/src/models/pitch.dart
+++ b/lib/src/models/pitch.dart
@@ -1,44 +1,122 @@
 import 'package:meta/meta.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_structure_exception.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_validation_exception.dart';
+import 'package:musicxml_parser/src/parser/xml_helper.dart';
 import 'package:musicxml_parser/src/utils/validation_utils.dart';
+import 'package:xml/xml.dart';
 
-/// Represents a pitch in music notation.
+/// Represents a musical pitch, including its step, octave, and alteration.
+///
+/// A pitch is defined by a step (A-G), an octave (0-9), and an optional
+/// alteration (e.g., sharp, flat). This class ensures that pitch values
+/// conform to standard musical notation.
+///
+/// Objects of this class are immutable.
 @immutable
 class Pitch {
-  /// The step of the pitch (C, D, E, F, G, A, B).
+  /// The musical step of the pitch, represented as a capital letter (C, D, E, F, G, A, B).
   final String step;
 
-  /// The octave number.
+  /// The octave number (0-9) in which the pitch resides.
   final int octave;
 
-  /// The alteration of the pitch (-1 for flat, 1 for sharp, etc.).
+  /// The chromatic alteration of the pitch.
+  ///
+  /// Positive values represent sharps (e.g., 1 for a single sharp),
+  /// negative values represent flats (e.g., -1 for a single flat),
+  /// and 0 or null represents no alteration. Typically ranges from -2 to 2.
   final int? alter;
 
   /// Creates a new [Pitch] instance.
   ///
-  /// Validates that the step is one of C, D, E, F, G, A, B and
-  /// the octave is within the valid range (0-9).
-  ///
-  /// Throws [MusicXmlValidationException] if validation fails.
+  /// The constructor itself does basic assertions if any, but robust validation
+  /// (e.g., ensuring step is a valid letter, octave is in range) is typically
+  /// handled by factory constructors like [Pitch.fromXmlElement] or validation utilities.
   const Pitch({
     required this.step,
     required this.octave,
     this.alter,
   });
 
-  /// Creates a new [Pitch] instance with validation.
+  /// Creates a new [Pitch] instance from an MusicXML `<pitch>` [element].
   ///
-  /// This factory constructor performs validation and throws
-  /// [MusicXmlValidationException] if the pitch is invalid.
-  factory Pitch.validated({
-    required String step,
-    required int octave,
-    int? alter,
-    int? line,
-    Map<String, dynamic>? context,
-  }) {
-    final pitch = Pitch(step: step, octave: octave, alter: alter);
-    ValidationUtils.validatePitch(pitch, line: line, context: context);
-    return pitch;
+  /// This factory parses the required `<step>` and `<octave>` elements,
+  /// and the optional `<alter>` element. It performs validation against
+  /// MusicXML rules (e.g., valid pitch steps, octave range, alter range).
+  ///
+  /// Throws [MusicXmlStructureException] if required XML elements are missing.
+  /// Throws [MusicXmlValidationException] if the parsed values are invalid
+  /// according to MusicXML specifications.
+  ///
+  /// Parameters:
+  ///   [element]: The XML element representing the `<pitch>`.
+  ///   [partId]: The ID of the part, used for context in error messages.
+  ///   [measureNumber]: The number of the measure, used for context in error messages.
+  factory Pitch.fromXmlElement(
+    XmlElement element,
+    String partId,
+    String measureNumber,
+  ) {
+    final line = XmlHelper.getLineNumber(element);
+
+    final stepElement = element.findElements('step').firstOrNull;
+    if (stepElement == null) {
+      throw MusicXmlStructureException(
+        'Required <step> element not found in <pitch>',
+        parentElement: 'pitch',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber},
+      );
+    }
+    final step = stepElement.innerText.trim();
+
+    final octaveElement = element.findElements('octave').firstOrNull;
+    if (octaveElement == null) {
+      throw MusicXmlStructureException(
+        'Required <octave> element not found in <pitch>',
+        parentElement: 'pitch',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber},
+      );
+    }
+    final octaveText = octaveElement.innerText.trim();
+    final octave = int.tryParse(octaveText);
+
+    final alterElement = element.findElements('alter').firstOrNull;
+    final alterText = alterElement?.innerText.trim();
+    final alter = alterText != null ? int.tryParse(alterText) : null;
+
+    // Perform validation after extracting values
+    if (!ValidationUtils.validPitchSteps.contains(step)) {
+      throw MusicXmlValidationException(
+        'Invalid pitch step: "$step". Must be one of ${ValidationUtils.validPitchSteps.join(", ")}.',
+        rule: 'pitch_step_invalid',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber, 'parsedStep': step},
+      );
+    }
+
+    if (octave == null ||
+        octave < ValidationUtils.minOctave ||
+        octave > ValidationUtils.maxOctave) {
+      throw MusicXmlValidationException(
+        'Invalid octave: "$octaveText". Must be an integer between ${ValidationUtils.minOctave} and ${ValidationUtils.maxOctave}.',
+        rule: 'pitch_octave_invalid',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber, 'parsedOctave': octaveText},
+      );
+    }
+
+    if (alterText != null && (alter == null || alter < -2 || alter > 2)) {
+      throw MusicXmlValidationException(
+        'Invalid alter value: "$alterText". If present, must be an integer between -2 and 2.',
+        rule: 'pitch_alter_invalid',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber, 'parsedAlter': alterText},
+      );
+    }
+
+    return Pitch(step: step, octave: octave, alter: alter);
   }
 
   @override

--- a/lib/src/models/pitch.dart
+++ b/lib/src/models/pitch.dart
@@ -103,7 +103,11 @@ class Pitch {
         'Invalid octave: "$octaveText". Must be an integer between ${ValidationUtils.minOctave} and ${ValidationUtils.maxOctave}.',
         rule: 'pitch_octave_invalid',
         line: line,
-        context: {'part': partId, 'measure': measureNumber, 'parsedOctave': octaveText},
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'parsedOctave': octaveText
+        },
       );
     }
 
@@ -112,7 +116,11 @@ class Pitch {
         'Invalid alter value: "$alterText". If present, must be an integer between -2 and 2.',
         rule: 'pitch_alter_invalid',
         line: line,
-        context: {'part': partId, 'measure': measureNumber, 'parsedAlter': alterText},
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'parsedAlter': alterText
+        },
       );
     }
 

--- a/lib/src/models/print_object.dart
+++ b/lib/src/models/print_object.dart
@@ -35,7 +35,8 @@ class PrintObject {
           pageNumber == other.pageNumber &&
           localPageLayout == other.localPageLayout &&
           localSystemLayout == other.localSystemLayout &&
-          const DeepCollectionEquality().equals(localStaffLayouts, other.localStaffLayouts);
+          const DeepCollectionEquality()
+              .equals(localStaffLayouts, other.localStaffLayouts);
 
   @override
   int get hashCode =>

--- a/lib/src/models/score.dart
+++ b/lib/src/models/score.dart
@@ -1,60 +1,75 @@
 import 'package:meta/meta.dart';
 import 'package:collection/collection.dart'; // For DeepCollectionEquality
 import 'package:musicxml_parser/src/models/appearance.dart';
-import 'package:musicxml_parser/src/models/credit.dart'; // Import for Credit
+import 'package:musicxml_parser/src/models/credit.dart';
 import 'package:musicxml_parser/src/models/identification.dart';
 import 'package:musicxml_parser/src/models/page_layout.dart';
 import 'package:musicxml_parser/src/models/part.dart';
 import 'package:musicxml_parser/src/models/work.dart';
-import 'system_layout.dart'; // New import
-import 'staff_layout.dart'; // New import
+import 'system_layout.dart';
+import 'staff_layout.dart';
 
-/// Represents a MusicXML score document.
+/// Represents a complete MusicXML score document.
+///
+/// This is the top-level object for a parsed MusicXML file. It contains
+/// metadata such as [version], [work] information, [identification] details,
+/// and a list of [parts] that make up the score. It also holds default
+/// layout information ([pageLayout], [defaultSystemLayout], [defaultStaffLayouts]),
+/// [scaling], and [appearance] settings.
+///
+/// Instances are typically created via [ScoreBuilder].
+/// Objects of this class are immutable.
 @immutable
 class Score {
-  /// The version of MusicXML used.
+  /// The version of the MusicXML format used for the score (e.g., "3.1", "4.0").
   final String version;
 
-  /// Information about the musical work.
+  /// Information about the musical work itself (e.g., title).
   final Work? work;
 
-  /// Metadata about the score.
+  /// Identification metadata for the score (e.g., composer, rights).
   final Identification? identification;
 
-  /// List of parts in the score.
+  /// The list of [Part] objects that constitute the score.
   final List<Part> parts;
 
-  /// Default page layout information.
-  final PageLayout? pageLayout; // Renamed from defaultPageLayout for consistency with existing
+  /// Default page layout settings for the score.
+  final PageLayout? pageLayout;
 
-  /// Default system layout information.
+  /// Default system layout settings (e.g., margins, distances between systems).
   final SystemLayout? defaultSystemLayout;
 
-  /// Default staff layout information.
+  /// List of default staff layout settings (e.g., staff distances).
   final List<StaffLayout> defaultStaffLayouts;
 
-  /// Scaling information.
+  /// Scaling information used for rendering (e.g., millimeters per tenth).
   final Scaling? scaling;
 
-  /// Appearance settings.
+  /// Default appearance settings (e.g., line widths, note sizes).
   final Appearance? appearance;
 
-  /// The title of the score.
+  /// The primary title of the score.
+  /// Often also found within [work] or [identification] elements.
   final String? title;
 
-  /// The composer of the score.
+  /// The primary composer of the score.
+  /// Often also found within [identification] elements.
   final String? composer;
 
-  /// A list of credits for the score.
+  /// A list of [Credit] entries for the score (e.g., copyright, arranger).
   final List<Credit>? credits;
 
   /// Creates a new [Score] instance.
+  ///
+  /// It is generally recommended to use [ScoreBuilder] for constructing [Score]
+  /// objects, as it simplifies the process of incrementally adding properties
+  /// during parsing.
   const Score({
     required this.version,
     this.work,
     this.identification,
     required this.parts,
-    this.pageLayout, // This is the default page layout
+    this.pageLayout,
     this.defaultSystemLayout,
     this.defaultStaffLayouts = const [],
     this.scaling,
@@ -133,5 +148,167 @@ class Score {
     }
     buffer.write('}');
     return buffer.toString();
+  }
+}
+
+/// Builder for creating [Score] objects incrementally.
+///
+/// This builder is useful during the parsing process for MusicXML `<score-partwise>`
+/// elements, allowing various score-level properties and parts to be added
+/// as they are parsed. The [build] method finalizes the score construction.
+///
+/// Example:
+/// ```dart
+/// final scoreBuilder = ScoreBuilder(version: "4.0", line: 1)
+///   .setTitle("My Great Symphony")
+///   .setComposer("J. S. Bach");
+/// scoreBuilder.addPart(violinPart);
+/// scoreBuilder.addPart(celloPart);
+/// final Score myScore = scoreBuilder.build();
+/// ```
+class ScoreBuilder {
+  String _version;
+  Work? _work;
+  Identification? _identification;
+  List<Part> _parts = [];
+  PageLayout? _pageLayout;
+  SystemLayout? _defaultSystemLayout;
+  List<StaffLayout> _defaultStaffLayouts = [];
+  Scaling? _scaling;
+  Appearance? _appearance;
+  String? _title;
+  String? _composer;
+  List<Credit>? _credits;
+
+  /// Line number in the XML for error reporting context.
+  final int? _line;
+  /// Additional context for error reporting.
+  final Map<String, dynamic>? _context;
+
+  /// Creates a [ScoreBuilder].
+  ///
+  /// [version] is the MusicXML version. Defaults to "3.0" if not provided or empty.
+  /// [line] and [context] can be provided for more detailed error messages.
+  ScoreBuilder({String? version, int? line, Map<String, dynamic>? context})
+      : _version = (version != null && version.isNotEmpty) ? version : "3.0",
+        _line = line,
+        _context = context;
+
+  /// Sets the MusicXML version. Defaults to "3.0" if [version] is empty.
+  ScoreBuilder setVersion(String version) {
+    _version = version.isNotEmpty ? version : "3.0";
+    return this;
+  }
+
+  /// Sets the [Work] information for the score.
+  ScoreBuilder setWork(Work? work) {
+    _work = work;
+    return this;
+  }
+
+  /// Sets the [Identification] metadata for the score.
+  ScoreBuilder setIdentification(Identification? identification) {
+    _identification = identification;
+    return this;
+  }
+
+  /// Sets all [Part]s for the score.
+  ScoreBuilder setParts(List<Part> parts) {
+    _parts = parts;
+    return this;
+  }
+
+  /// Adds a single [Part] to the score.
+  ScoreBuilder addPart(Part part) {
+    _parts.add(part);
+    return this;
+  }
+
+  /// Sets the default [PageLayout] for the score.
+  ScoreBuilder setPageLayout(PageLayout? pageLayout) {
+    _pageLayout = pageLayout;
+    return this;
+  }
+
+  /// Sets the default [SystemLayout] for the score.
+  ScoreBuilder setDefaultSystemLayout(SystemLayout? systemLayout) {
+    _defaultSystemLayout = systemLayout;
+    return this;
+  }
+
+  /// Sets all default [StaffLayout]s for the score.
+  ScoreBuilder setDefaultStaffLayouts(List<StaffLayout> staffLayouts) {
+    _defaultStaffLayouts = staffLayouts;
+    return this;
+  }
+
+  /// Adds a single default [StaffLayout] to the score.
+  ScoreBuilder addDefaultStaffLayout(StaffLayout staffLayout) {
+    _defaultStaffLayouts.add(staffLayout);
+    return this;
+  }
+
+  /// Sets the [Scaling] information for the score.
+  ScoreBuilder setScaling(Scaling? scaling) {
+    _scaling = scaling;
+    return this;
+  }
+
+  /// Sets the default [Appearance] settings for the score.
+  ScoreBuilder setAppearance(Appearance? appearance) {
+    _appearance = appearance;
+    return this;
+  }
+
+  /// Sets the primary title of the score.
+  ScoreBuilder setTitle(String? title) {
+    _title = title;
+    return this;
+  }
+
+  /// Sets the primary composer of the score.
+  ScoreBuilder setComposer(String? composer) {
+    _composer = composer;
+    return this;
+  }
+
+  /// Sets all [Credit]s for the score.
+  ScoreBuilder setCredits(List<Credit>? credits) {
+    _credits = credits;
+    return this;
+  }
+
+  /// Adds a single [Credit] to the score.
+  ScoreBuilder addCredit(Credit credit) {
+    _credits ??= [];
+    _credits!.add(credit);
+    return this;
+  }
+
+  /// Builds the [Score] instance.
+  ///
+  /// This method constructs the [Score] object from the properties set
+  /// on the builder. It ensures that a version is set (defaulting to "3.0")
+  /// and that the list of parts is initialized.
+  Score build() {
+    // Basic validation: parts list should not be null, version should be present.
+    // MusicXML spec implies a score typically has parts, but an empty list is technically possible
+    // if the <score-partwise> element is empty.
+    // Version is required by the Score constructor and handled by builder's default.
+
+    return Score(
+      version: _version,
+      work: _work,
+      identification: _identification,
+      parts: _parts,
+      pageLayout: _pageLayout,
+      defaultSystemLayout: _defaultSystemLayout,
+      defaultStaffLayouts: _defaultStaffLayouts,
+      scaling: _scaling,
+      appearance: _appearance,
+      title: _title,
+      composer: _composer,
+      credits: _credits,
+    );
   }
 }

--- a/lib/src/models/score.dart
+++ b/lib/src/models/score.dart
@@ -90,7 +90,8 @@ class Score {
           const DeepCollectionEquality().equals(parts, other.parts) &&
           pageLayout == other.pageLayout &&
           defaultSystemLayout == other.defaultSystemLayout &&
-          const DeepCollectionEquality().equals(defaultStaffLayouts, other.defaultStaffLayouts) &&
+          const DeepCollectionEquality()
+              .equals(defaultStaffLayouts, other.defaultStaffLayouts) &&
           scaling == other.scaling &&
           appearance == other.appearance &&
           title == other.title &&
@@ -182,6 +183,7 @@ class ScoreBuilder {
 
   /// Line number in the XML for error reporting context.
   final int? _line;
+
   /// Additional context for error reporting.
   final Map<String, dynamic>? _context;
 

--- a/lib/src/models/slur.dart
+++ b/lib/src/models/slur.dart
@@ -34,9 +34,7 @@ class Slur {
 
   @override
   int get hashCode =>
-      type.hashCode ^
-      number.hashCode ^
-      (placement?.hashCode ?? 0);
+      type.hashCode ^ number.hashCode ^ (placement?.hashCode ?? 0);
 
   @override
   String toString() {

--- a/lib/src/models/staff_layout.dart
+++ b/lib/src/models/staff_layout.dart
@@ -2,7 +2,8 @@ import 'package:meta/meta.dart';
 
 @immutable
 class StaffLayout {
-  final int staffNumber; // staff number this layout applies to (default 1 if not present in XML attribute)
+  final int
+      staffNumber; // staff number this layout applies to (default 1 if not present in XML attribute)
   final double? staffDistance; // distance from previous staff
 
   const StaffLayout({

--- a/lib/src/models/time_signature.dart
+++ b/lib/src/models/time_signature.dart
@@ -1,18 +1,33 @@
 import 'package:meta/meta.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_structure_exception.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_validation_exception.dart';
+import 'package:musicxml_parser/src/parser/xml_helper.dart';
 import 'package:musicxml_parser/src/utils/validation_utils.dart';
+import 'package:xml/xml.dart';
 
 /// Represents a time signature in a musical score.
+///
+/// A time signature is defined by a numerator ([beats]) indicating the number
+/// of beats per measure, and a denominator ([beatType]) indicating the
+/// note value that represents one beat.
+///
+/// Objects of this class are immutable.
 @immutable
 class TimeSignature {
-  /// The numerator of the time signature (beats per measure).
+  /// The numerator of the time signature, indicating the number of beats per measure.
+  /// Must be a positive integer.
   final int beats;
 
-  /// The denominator of the time signature (beat unit).
+  /// The denominator of the time signature, indicating the note value that
+  /// represents one beat (e.g., 4 for a quarter note, 2 for a half note).
+  /// Must be a positive power of 2.
   final int beatType;
 
   /// Creates a new [TimeSignature] instance.
   ///
-  /// [beats] must be positive and [beatType] must be a positive power of 2.
+  /// It's recommended to use [TimeSignature.validated] or
+  /// [TimeSignature.fromXmlElement] for creating instances, as they include
+  /// validation against MusicXML rules.
   const TimeSignature({
     required this.beats,
     required this.beatType,
@@ -20,8 +35,16 @@ class TimeSignature {
 
   /// Creates a new [TimeSignature] instance with validation.
   ///
-  /// This factory constructor performs validation and throws
-  /// [MusicXmlValidationException] if the time signature is invalid.
+  /// This factory constructor performs validation against MusicXML rules
+  /// (e.g., positive beats, beatType is a power of 2).
+  ///
+  /// Throws [MusicXmlValidationException] if the time signature is invalid.
+  ///
+  /// Parameters:
+  ///   [beats]: The numerator of the time signature.
+  ///   [beatType]: The denominator of the time signature.
+  ///   [line]: The line number in the XML document (for context in error messages).
+  ///   [context]: Additional context for error messages.
   factory TimeSignature.validated({
     required int beats,
     required int beatType,
@@ -29,9 +52,87 @@ class TimeSignature {
     Map<String, dynamic>? context,
   }) {
     final timeSignature = TimeSignature(beats: beats, beatType: beatType);
+    // ValidationUtils.validateTimeSignature will throw if invalid.
     ValidationUtils.validateTimeSignature(timeSignature,
         line: line, context: context);
     return timeSignature;
+  }
+
+  /// Creates a new [TimeSignature] instance from a MusicXML `<time>` [element].
+  ///
+  /// This factory parses the required `<beats>` and `<beat-type>` elements
+  /// and then validates the parsed values.
+  ///
+  /// Throws [MusicXmlStructureException] if required XML elements are missing.
+  /// Throws [MusicXmlValidationException] if the parsed values are invalid.
+  ///
+  /// Parameters:
+  ///   [element]: The XML element representing the `<time>`.
+  ///   [partId]: The ID of the part (for context in error messages).
+  ///   [measureNumber]: The number of the measure (for context in error messages).
+  factory TimeSignature.fromXmlElement(
+    XmlElement element,
+    String partId,
+    String measureNumber,
+  ) {
+    final line = XmlHelper.getLineNumber(element);
+
+    final beatsElement = element.findElements('beats').firstOrNull;
+    if (beatsElement == null) {
+      throw MusicXmlStructureException(
+        'Required <beats> element not found in <time>',
+        parentElement: 'time',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber},
+      );
+    }
+    final beatsText = beatsElement.innerText.trim();
+    final beats = int.tryParse(beatsText);
+
+    final beatTypeElement = element.findElements('beat-type').firstOrNull;
+    if (beatTypeElement == null) {
+      throw MusicXmlStructureException(
+        'Required <beat-type> element not found in <time>',
+        parentElement: 'time',
+        line: line,
+        context: {'part': partId, 'measure': measureNumber},
+      );
+    }
+    final beatTypeText = beatTypeElement.innerText.trim();
+    final beatType = int.tryParse(beatTypeText);
+
+    if (beats == null) {
+      throw MusicXmlValidationException(
+        'Invalid time signature beats (numerator) value: "$beatsText". Must be an integer.',
+        rule: 'time_beats_invalid',
+        line: XmlHelper.getLineNumber(beatsElement),
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'parsedBeats': beatsText
+        },
+      );
+    }
+    if (beatType == null) {
+      throw MusicXmlValidationException(
+        'Invalid time signature beat-type (denominator) value: "$beatTypeText". Must be an integer.',
+        rule: 'time_beat_type_invalid',
+        line: XmlHelper.getLineNumber(beatTypeElement),
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'parsedBeatType': beatTypeText
+        },
+      );
+    }
+
+    // Use the .validated factory to ensure consistent validation logic
+    return TimeSignature.validated(
+      beats: beats,
+      beatType: beatType,
+      line: line,
+      context: {'part': partId, 'measure': measureNumber},
+    );
   }
 
   @override

--- a/lib/src/parser/attributes_parser.dart
+++ b/lib/src/parser/attributes_parser.dart
@@ -91,10 +91,10 @@ class AttributesParser {
   ) {
     try {
       return KeySignature.fromXmlElement(element, partId, measureNumber);
-    } on MusicXmlStructureException catch (e) {
+    } on MusicXmlStructureException {
       // Re-throw, or add more context if needed
       rethrow;
-    } on MusicXmlValidationException catch (e) {
+    } on MusicXmlValidationException {
       // Re-throw, or add more context if needed
       rethrow;
     }
@@ -108,10 +108,10 @@ class AttributesParser {
   ) {
     try {
       return TimeSignature.fromXmlElement(element, partId, measureNumber);
-    } on MusicXmlStructureException catch (e) {
+    } on MusicXmlStructureException {
       // Re-throw, or add more context if needed
       rethrow;
-    } on MusicXmlValidationException catch (e) {
+    } on MusicXmlValidationException {
       // Re-throw, or add more context if needed
       rethrow;
     }

--- a/lib/src/parser/attributes_parser.dart
+++ b/lib/src/parser/attributes_parser.dart
@@ -1,4 +1,5 @@
 import 'package:musicxml_parser/src/exceptions/musicxml_parse_exception.dart';
+import 'package:musicxml_parser/src/exceptions/musicxml_structure_exception.dart';
 import 'package:musicxml_parser/src/exceptions/musicxml_validation_exception.dart';
 import 'package:musicxml_parser/src/models/key_signature.dart';
 import 'package:musicxml_parser/src/models/time_signature.dart';
@@ -82,95 +83,37 @@ class AttributesParser {
     };
   }
 
-  /// Parses a key element into a [KeySignature] object.
+  /// Parses a key element into a [KeySignature] object using the KeySignature.fromXmlElement factory.
   KeySignature _parseKeySignature(
     XmlElement element,
     String partId,
     String measureNumber,
   ) {
-    final line = XmlHelper.getLineNumber(element);
-
-    // Parse fifths
-    final fifthsElement = element.findElements('fifths').firstOrNull;
-    final fifthsText = fifthsElement?.innerText.trim();
-    final fifths = fifthsText != null ? int.tryParse(fifthsText) : null;
-
-    if (fifths == null) {
-      throw MusicXmlValidationException(
-        'Invalid key signature fifths value: $fifthsText',
-        context: {
-          'part': partId,
-          'measure': measureNumber,
-          'line': line,
-        },
-      );
+    try {
+      return KeySignature.fromXmlElement(element, partId, measureNumber);
+    } on MusicXmlStructureException catch (e) {
+      // Re-throw, or add more context if needed
+      rethrow;
+    } on MusicXmlValidationException catch (e) {
+      // Re-throw, or add more context if needed
+      rethrow;
     }
-
-    // Parse mode (optional)
-    final modeElement = element.findElements('mode').firstOrNull;
-    final mode = modeElement?.innerText.trim();
-
-    return KeySignature.validated(
-      fifths: fifths,
-      mode: mode,
-      line: line,
-      context: {
-        'part': partId,
-        'measure': measureNumber,
-      },
-    );
   }
 
-  /// Parses a time element into a [TimeSignature] object.
+  /// Parses a time element into a [TimeSignature] object using the TimeSignature.fromXmlElement factory.
   TimeSignature _parseTimeSignature(
     XmlElement element,
     String partId,
     String measureNumber,
   ) {
-    final line = XmlHelper.getLineNumber(element);
-
-    // Parse beats (numerator)
-    final beatsElement = element.findElements('beats').firstOrNull;
-    final beatsText = beatsElement?.innerText.trim();
-    final beats = beatsText != null ? int.tryParse(beatsText) : null;
-
-    if (beats == null || beats <= 0) {
-      throw MusicXmlValidationException(
-        'Invalid time signature beats (numerator) value: $beatsText',
-        context: {
-          'part': partId,
-          'measure': measureNumber,
-          'line': line,
-        },
-      );
+    try {
+      return TimeSignature.fromXmlElement(element, partId, measureNumber);
+    } on MusicXmlStructureException catch (e) {
+      // Re-throw, or add more context if needed
+      rethrow;
+    } on MusicXmlValidationException catch (e) {
+      // Re-throw, or add more context if needed
+      rethrow;
     }
-
-    // Parse beat-type (denominator)
-    final beatTypeElement = element.findElements('beat-type').firstOrNull;
-    final beatTypeText = beatTypeElement?.innerText.trim();
-    final beatType = beatTypeText != null ? int.tryParse(beatTypeText) : null;
-
-    if (beatType == null || beatType <= 0) {
-      throw MusicXmlValidationException(
-        'Invalid time signature beat-type (denominator) value: $beatTypeText',
-        context: {
-          'part': partId,
-          'measure': measureNumber,
-          'line': line,
-        },
-      );
-    }
-
-    // Note: We could use symbol attribute for special time signatures in the future
-
-    return TimeSignature.validated(
-      beats: beats,
-      beatType: beatType,
-      line: line,
-      context: {
-        'part': partId,
-        'measure': measureNumber,
-      },
-    );
   }
 }

--- a/lib/src/parser/measure_parser.dart
+++ b/lib/src/parser/measure_parser.dart
@@ -5,7 +5,6 @@ import 'package:musicxml_parser/src/models/beam.dart';
 import 'package:musicxml_parser/src/models/ending.dart'; // Import for Ending
 import 'package:musicxml_parser/src/models/key_signature.dart';
 import 'package:musicxml_parser/src/models/measure.dart';
-import 'package:musicxml_parser/src/models/note.dart';
 import 'package:musicxml_parser/src/models/time_signature.dart';
 import 'package:musicxml_parser/src/models/direction_words.dart';
 import 'package:musicxml_parser/src/models/print_object.dart'; // New import
@@ -107,20 +106,23 @@ class MeasureParser {
     final width = widthAttr != null ? double.tryParse(widthAttr) : null;
 
     // Initialize MeasureBuilder
-    final measureBuilder = MeasureBuilder(number, line: line, context: {'part': partId})
+    final measureBuilder = MeasureBuilder(number,
+            line: line, context: {'part': partId})
         .setIsPickup(isPickup)
         .setWidth(width)
         .setKeySignature(inheritedKeySignature) // Set initial inherited values
         .setTimeSignature(inheritedTimeSignature);
 
     int? currentDivisions = inheritedDivisions;
-    final List<Beam> individualBeams = []; // Collect individual beams for later merging
+    final List<Beam> individualBeams =
+        []; // Collect individual beams for later merging
 
     // Process measure content
     for (final child in element.childElements) {
       switch (child.name.local) {
         case 'attributes':
-          final attributesData = _attributesParser.parse(child, partId, number, currentDivisions);
+          final attributesData =
+              _attributesParser.parse(child, partId, number, currentDivisions);
           currentDivisions = attributesData['divisions'] ?? currentDivisions;
           // Use the new values if present, otherwise keep what was inherited or previously set in the builder.
           if (attributesData['keySignature'] != null) {
@@ -131,14 +133,16 @@ class MeasureParser {
           }
           break;
         case 'note':
-          final note = _noteParser.parse(child, currentDivisions, partId, number);
+          final note =
+              _noteParser.parse(child, currentDivisions, partId, number);
           if (note != null) {
             // To get the noteIndex, we need to know how many notes are already in the builder.
             // Assuming MeasureBuilder._notes is not directly accessible,
             // we might need a getter in MeasureBuilder or manage notes list temporarily here.
             // For simplicity, if MeasureBuilder's addNote is the only way notes are added,
             // the current length *before* adding is the index.
-            final noteIndex = measureBuilder.debugGetNotesCount(); // Needs a temporary getter or local list
+            final noteIndex = measureBuilder
+                .debugGetNotesCount(); // Needs a temporary getter or local list
             measureBuilder.addNote(note);
             individualBeams.addAll(BeamParser.parse(child, noteIndex, number));
           }
@@ -176,7 +180,8 @@ class MeasureParser {
   }
 
   /// Parses a <backup> or <forward> element.
-  void _parseBackupOrForward(XmlElement element, String type, String partId, String measureNumber) {
+  void _parseBackupOrForward(
+      XmlElement element, String type, String partId, String measureNumber) {
     final durationElement = element.findElements('duration').firstOrNull;
     if (durationElement == null) {
       throw MusicXmlStructureException(
@@ -192,7 +197,11 @@ class MeasureParser {
         "Invalid or missing duration value for <$type>.",
         parentElement: type,
         line: XmlHelper.getLineNumber(durationElement),
-        context: {'part': partId, 'measure': measureNumber, 'parsedDuration': duration},
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'parsedDuration': duration
+        },
       );
     }
     warningSystem.addWarning(
@@ -212,9 +221,11 @@ class MeasureParser {
   /// Parses a <barline> element.
   Barline _parseBarline(XmlElement barlineElement) {
     String? location = barlineElement.getAttribute('location');
-    XmlElement? barStyleElement = barlineElement.findElements('bar-style').firstOrNull;
+    XmlElement? barStyleElement =
+        barlineElement.findElements('bar-style').firstOrNull;
     String? barStyle = barStyleElement?.innerText.trim();
-    XmlElement? repeatElement = barlineElement.findElements('repeat').firstOrNull;
+    XmlElement? repeatElement =
+        barlineElement.findElements('repeat').firstOrNull;
     String? repeatDirection;
     int? repeatTimes;
     if (repeatElement != null) {
@@ -232,18 +243,22 @@ class MeasureParser {
   }
 
   /// Parses an <ending> element.
-  Ending? _parseEnding(XmlElement endingElement, String partId, String measureNumber) {
+  Ending? _parseEnding(
+      XmlElement endingElement, String partId, String measureNumber) {
     String? endingNumber = endingElement.getAttribute('number');
     if (endingNumber == null || endingNumber.isEmpty) {
-        final textContent = endingElement.innerText.trim();
-        if (textContent.isNotEmpty) {
-            endingNumber = textContent;
-        }
+      final textContent = endingElement.innerText.trim();
+      if (textContent.isNotEmpty) {
+        endingNumber = textContent;
+      }
     }
     String? type = endingElement.getAttribute('type');
     String? printObjectAttr = endingElement.getAttribute('print-object');
 
-    if (endingNumber != null && endingNumber.isNotEmpty && type != null && type.isNotEmpty) {
+    if (endingNumber != null &&
+        endingNumber.isNotEmpty &&
+        type != null &&
+        type.isNotEmpty) {
       return Ending(
           number: endingNumber,
           type: type,
@@ -260,9 +275,11 @@ class MeasureParser {
   }
 
   /// Parses a <direction> element for <words>.
-  List<WordsDirection> _parseDirection(XmlElement directionElement, String partId, String measureNumber) {
+  List<WordsDirection> _parseDirection(
+      XmlElement directionElement, String partId, String measureNumber) {
     final wordsDirections = <WordsDirection>[];
-    for (final directionTypeElement in directionElement.findElements('direction-type')) {
+    for (final directionTypeElement
+        in directionElement.findElements('direction-type')) {
       for (final wordsElement in directionTypeElement.findElements('words')) {
         final text = wordsElement.innerText.trim();
         if (text.isNotEmpty) {
@@ -294,19 +311,22 @@ class MeasureParser {
     final blankPage = blankPageStr != null ? int.tryParse(blankPageStr) : null;
 
     PageLayout? localPageLayout;
-    final pageLayoutElement = printElement.findElements('page-layout').firstOrNull;
+    final pageLayoutElement =
+        printElement.findElements('page-layout').firstOrNull;
     if (pageLayoutElement != null) {
       localPageLayout = PageLayoutParser().parse(pageLayoutElement);
     }
 
     SystemLayout? localSystemLayout;
-    final systemLayoutElement = printElement.findElements('system-layout').firstOrNull;
+    final systemLayoutElement =
+        printElement.findElements('system-layout').firstOrNull;
     if (systemLayoutElement != null) {
       localSystemLayout = SystemLayoutParser().parse(systemLayoutElement);
     }
 
     List<StaffLayout> localStaffLayouts = [];
-    for (final staffLayoutElement in printElement.findElements('staff-layout')) {
+    for (final staffLayoutElement
+        in printElement.findElements('staff-layout')) {
       localStaffLayouts.add(StaffLayoutParser().parse(staffLayoutElement));
     }
 

--- a/lib/src/parser/note_parser.dart
+++ b/lib/src/parser/note_parser.dart
@@ -68,7 +68,7 @@ class NoteParser {
         if (effectiveParentDivisions == null || effectiveParentDivisions <= 0) {
           warningSystem.addWarning(
             'No valid divisions specified for note with duration. Using default divisions value 1.',
-            category: 'note_divisions',
+            category: WarningCategories.noteDivisions,
             context: {
               'part': partId,
               'measure': measureNumber,
@@ -193,8 +193,10 @@ class NoteParser {
     if (timeModificationElement == null) return null;
 
     final tmLine = XmlHelper.getLineNumber(timeModificationElement);
-    final actualNotesElement = timeModificationElement.findElements('actual-notes').firstOrNull;
-    final normalNotesElement = timeModificationElement.findElements('normal-notes').firstOrNull;
+    final actualNotesElement =
+        timeModificationElement.findElements('actual-notes').firstOrNull;
+    final normalNotesElement =
+        timeModificationElement.findElements('normal-notes').firstOrNull;
 
     if (actualNotesElement == null) {
       throw MusicXmlStructureException(
@@ -235,11 +237,14 @@ class NoteParser {
       );
     }
 
-    final normalTypeElement = timeModificationElement.findElements('normal-type').firstOrNull;
+    final normalTypeElement =
+        timeModificationElement.findElements('normal-type').firstOrNull;
     final normalType = normalTypeElement?.innerText.trim();
 
-    final normalDotElements = timeModificationElement.findElements('normal-dot');
-    final int? normalDotCount = normalDotElements.isNotEmpty ? normalDotElements.length : null;
+    final normalDotElements =
+        timeModificationElement.findElements('normal-dot');
+    final int? normalDotCount =
+        normalDotElements.isNotEmpty ? normalDotElements.length : null;
 
     try {
       return TimeModification.validated(
@@ -248,7 +253,11 @@ class NoteParser {
         normalType: normalType,
         normalDotCount: normalDotCount,
         line: tmLine,
-        context: {'part': partId, 'measure': measureNumber, 'noteLine': noteLine},
+        context: {
+          'part': partId,
+          'measure': measureNumber,
+          'noteLine': noteLine
+        },
       );
     } on MusicXmlValidationException catch (e) {
       warningSystem.addWarning(
@@ -289,34 +298,52 @@ class NoteParser {
               '<slur> element missing required "type" attribute',
               parentElement: 'notations',
               line: XmlHelper.getLineNumber(notationChild),
-              context: {'part': partId, 'measure': measureNumber, 'noteLine': noteLine},
+              context: {
+                'part': partId,
+                'measure': measureNumber,
+                'noteLine': noteLine
+              },
             );
           }
           final String? numberStr = notationChild.getAttribute('number');
-          final int numberAttr = (numberStr != null && numberStr.isNotEmpty ? int.tryParse(numberStr) : null) ?? 1;
+          final int numberAttr = (numberStr != null && numberStr.isNotEmpty
+                  ? int.tryParse(numberStr)
+                  : null) ??
+              1;
           final String? placementAttr = notationChild.getAttribute('placement');
-          slurs.add(Slur(type: typeAttr, number: numberAttr, placement: placementAttr));
+          slurs.add(Slur(
+              type: typeAttr, number: numberAttr, placement: placementAttr));
           break;
         case 'articulations':
           for (final specificArtElement in notationChild.childElements) {
             final String artType = specificArtElement.name.local;
             if (artType.isNotEmpty) {
-              final String? placementAttr = specificArtElement.getAttribute('placement');
-              articulations.add(Articulation(type: artType, placement: placementAttr));
+              final String? placementAttr =
+                  specificArtElement.getAttribute('placement');
+              articulations
+                  .add(Articulation(type: artType, placement: placementAttr));
             }
           }
           break;
         case 'tied':
           final String? typeAttr = notationChild.getAttribute('type');
-          if (typeAttr == null || (typeAttr != 'start' && typeAttr != 'stop' && typeAttr != 'continue')) {
+          if (typeAttr == null ||
+              (typeAttr != 'start' &&
+                  typeAttr != 'stop' &&
+                  typeAttr != 'continue')) {
             warningSystem.addWarning(
               '<tied> element has invalid or missing "type" attribute. Found: "$typeAttr". Skipping tie.',
               category: WarningCategories.structure,
               line: XmlHelper.getLineNumber(notationChild),
-              context: {'part': partId, 'measure': measureNumber, 'noteLine': noteLine},
+              context: {
+                'part': partId,
+                'measure': measureNumber,
+                'noteLine': noteLine
+              },
             );
           } else {
-            final String? placementAttr = notationChild.getAttribute('placement');
+            final String? placementAttr =
+                notationChild.getAttribute('placement');
             ties.add(Tie(type: typeAttr, placement: placementAttr));
           }
           break;

--- a/lib/src/parser/note_parser.dart
+++ b/lib/src/parser/note_parser.dart
@@ -8,7 +8,6 @@ import 'package:musicxml_parser/src/models/slur.dart'; // Import for Slur
 import 'package:musicxml_parser/src/models/tie.dart'; // Import for Tie
 import 'package:musicxml_parser/src/models/time_modification.dart';
 import 'package:musicxml_parser/src/parser/xml_helper.dart';
-import 'package:musicxml_parser/src/utils/validation_utils.dart';
 import 'package:musicxml_parser/src/utils/warning_system.dart';
 import 'package:xml/xml.dart';
 
@@ -359,11 +358,11 @@ class NoteParser {
   Pitch _parsePitch(XmlElement element, String partId, String measureNumber) {
     try {
       return Pitch.fromXmlElement(element, partId, measureNumber);
-    } on MusicXmlStructureException catch (e) {
+    } on MusicXmlStructureException {
       // Re-throw with more specific context if needed, or let it propagate
       // For now, just rethrowing as the factory method should provide good context.
       rethrow;
-    } on MusicXmlValidationException catch (e) {
+    } on MusicXmlValidationException {
       // Similarly, re-throw or handle/log
       rethrow;
     }

--- a/lib/src/parser/page_layout_parser.dart
+++ b/lib/src/parser/page_layout_parser.dart
@@ -8,15 +8,21 @@ class PageLayoutParser {
   PageLayout parse(XmlElement element) {
     // TODO: Implement parsing logic
     // Placeholder implementation
-    final pageHeight = XmlHelper.getElementTextAsDouble(element.findElements('page-height').firstOrNull);
-    final pageWidth = XmlHelper.getElementTextAsDouble(element.findElements('page-width').firstOrNull);
+    final pageHeight = XmlHelper.getElementTextAsDouble(
+        element.findElements('page-height').firstOrNull);
+    final pageWidth = XmlHelper.getElementTextAsDouble(
+        element.findElements('page-width').firstOrNull);
     final margins = <PageMargins>[];
     for (final marginElement in element.findElements('page-margins')) {
       final type = marginElement.getAttribute('type');
-      final left = XmlHelper.getElementTextAsDouble(marginElement.findElements('left-margin').firstOrNull);
-      final right = XmlHelper.getElementTextAsDouble(marginElement.findElements('right-margin').firstOrNull);
-      final top = XmlHelper.getElementTextAsDouble(marginElement.findElements('top-margin').firstOrNull);
-      final bottom = XmlHelper.getElementTextAsDouble(marginElement.findElements('bottom-margin').firstOrNull);
+      final left = XmlHelper.getElementTextAsDouble(
+          marginElement.findElements('left-margin').firstOrNull);
+      final right = XmlHelper.getElementTextAsDouble(
+          marginElement.findElements('right-margin').firstOrNull);
+      final top = XmlHelper.getElementTextAsDouble(
+          marginElement.findElements('top-margin').firstOrNull);
+      final bottom = XmlHelper.getElementTextAsDouble(
+          marginElement.findElements('bottom-margin').firstOrNull);
       margins.add(PageMargins(
         type: type,
         leftMargin: left,
@@ -39,14 +45,17 @@ class ScalingParser {
   Scaling parse(XmlElement element) {
     // TODO: Implement parsing logic if needed separately, or integrate into ScoreParser/DefaultsParser
     // Placeholder implementation
-    final millimeters = XmlHelper.getElementTextAsDouble(element.findElements('millimeters').firstOrNull);
-    final tenths = XmlHelper.getElementTextAsDouble(element.findElements('tenths').firstOrNull);
+    final millimeters = XmlHelper.getElementTextAsDouble(
+        element.findElements('millimeters').firstOrNull);
+    final tenths = XmlHelper.getElementTextAsDouble(
+        element.findElements('tenths').firstOrNull);
 
     if (millimeters == null || tenths == null) {
       // Or throw an exception, depending on how strict parsing should be
       // For now, returning a default or handling nullability in the Scaling model might be options
       // However, the model expects non-null values.
-      throw Exception('<scaling> element must contain <millimeters> and <tenths>');
+      throw Exception(
+          '<scaling> element must contain <millimeters> and <tenths>');
     }
     return Scaling(millimeters: millimeters, tenths: tenths);
   }

--- a/lib/src/parser/part_parser.dart
+++ b/lib/src/parser/part_parser.dart
@@ -1,7 +1,6 @@
 import 'package:musicxml_parser/src/exceptions/musicxml_structure_exception.dart';
 import 'package:musicxml_parser/src/exceptions/musicxml_validation_exception.dart';
 import 'package:musicxml_parser/src/models/key_signature.dart';
-import 'package:musicxml_parser/src/models/measure.dart';
 import 'package:musicxml_parser/src/models/part.dart';
 import 'package:musicxml_parser/src/models/time_signature.dart';
 import 'package:musicxml_parser/src/parser/measure_parser.dart';
@@ -93,9 +92,11 @@ class PartParser {
 
       // Divisions: If the current measure defined new divisions, use that.
       // Otherwise, continue with the previously active divisions.
-      final attributesInMeasure = measureElement.findElements('attributes').firstOrNull;
+      final attributesInMeasure =
+          measureElement.findElements('attributes').firstOrNull;
       if (attributesInMeasure != null) {
-        final divisionsElement = attributesInMeasure.findElements('divisions').firstOrNull;
+        final divisionsElement =
+            attributesInMeasure.findElements('divisions').firstOrNull;
         if (divisionsElement != null) {
           final newDivisions = int.tryParse(divisionsElement.innerText.trim());
           if (newDivisions != null && newDivisions > 0) {

--- a/lib/src/parser/score_parser.dart
+++ b/lib/src/parser/score_parser.dart
@@ -98,9 +98,10 @@ class ScoreParser {
     final defaults = _parseDefaults(element.getElement('defaults'));
 
     // Initialize ScoreBuilder
-    final scoreBuilder = ScoreBuilder(version: version, line: XmlHelper.getLineNumber(element))
-        .setTitle(title)
-        .setComposer(composer);
+    final scoreBuilder =
+        ScoreBuilder(version: version, line: XmlHelper.getLineNumber(element))
+            .setTitle(title)
+            .setComposer(composer);
 
     // Set parts
     scoreBuilder.setParts(parts);
@@ -145,7 +146,8 @@ class ScoreParser {
         : null;
 
     final systemLayout = defaultsElement.getElement('system-layout') != null
-        ? SystemLayoutParser().parse(defaultsElement.getElement('system-layout')!)
+        ? SystemLayoutParser()
+            .parse(defaultsElement.getElement('system-layout')!)
         : null;
 
     final staffLayouts = defaultsElement
@@ -169,9 +171,12 @@ class ScoreParser {
     final creditElements = scoreElement.findElements('credit');
     for (final creditElement in creditElements) {
       String? pageStr = creditElement.getAttribute('page');
-      int? page = (pageStr != null && pageStr.isNotEmpty ? int.tryParse(pageStr) : null);
+      int? page = (pageStr != null && pageStr.isNotEmpty
+          ? int.tryParse(pageStr)
+          : null);
 
-      XmlElement? creditTypeElement = creditElement.findElements('credit-type').firstOrNull;
+      XmlElement? creditTypeElement =
+          creditElement.findElements('credit-type').firstOrNull;
       String? creditType = creditTypeElement?.innerText.trim();
 
       List<String> creditWordsList = [];
@@ -179,14 +184,17 @@ class ScoreParser {
       for (final wordsElement in creditWordsElements) {
         final text = wordsElement.innerText.trim();
         if (text.isNotEmpty) {
-            creditWordsList.add(text);
+          creditWordsList.add(text);
         }
       }
 
-      if ((creditType != null && creditType.isNotEmpty) || creditWordsList.isNotEmpty) {
-         parsedCredits.add(Credit(page: page, creditType: creditType, creditWords: creditWordsList));
+      if ((creditType != null && creditType.isNotEmpty) ||
+          creditWordsList.isNotEmpty) {
+        parsedCredits.add(Credit(
+            page: page, creditType: creditType, creditWords: creditWordsList));
       } else if (page != null) {
-         parsedCredits.add(Credit(page: page, creditType: creditType, creditWords: creditWordsList));
+        parsedCredits.add(Credit(
+            page: page, creditType: creditType, creditWords: creditWordsList));
       }
     }
     return parsedCredits;

--- a/lib/src/parser/staff_layout_parser.dart
+++ b/lib/src/parser/staff_layout_parser.dart
@@ -13,7 +13,8 @@ class StaffLayoutParser {
 
     return StaffLayout(
       staffNumber: staffNumber,
-      staffDistance: XmlHelper.getElementTextAsDouble(element.findElements('staff-distance').firstOrNull),
+      staffDistance: XmlHelper.getElementTextAsDouble(
+          element.findElements('staff-distance').firstOrNull),
     );
   }
 }

--- a/lib/src/parser/system_layout_parser.dart
+++ b/lib/src/parser/system_layout_parser.dart
@@ -12,8 +12,10 @@ class SystemLayoutParser {
     final marginsElement = element.findElements('system-margins').firstOrNull;
     if (marginsElement != null) {
       margins = SystemMargins(
-        leftMargin: XmlHelper.getElementTextAsDouble(marginsElement.findElements('left-margin').firstOrNull),
-        rightMargin: XmlHelper.getElementTextAsDouble(marginsElement.findElements('right-margin').firstOrNull),
+        leftMargin: XmlHelper.getElementTextAsDouble(
+            marginsElement.findElements('left-margin').firstOrNull),
+        rightMargin: XmlHelper.getElementTextAsDouble(
+            marginsElement.findElements('right-margin').firstOrNull),
       );
     }
 
@@ -21,15 +23,19 @@ class SystemLayoutParser {
     final dividersElement = element.findElements('system-dividers').firstOrNull;
     if (dividersElement != null) {
       dividers = SystemDividers(
-        leftDivider: XmlHelper.getElementTextAsBool(dividersElement.findElements('left-divider').firstOrNull),
-        rightDivider: XmlHelper.getElementTextAsBool(dividersElement.findElements('right-divider').firstOrNull),
+        leftDivider: XmlHelper.getElementTextAsBool(
+            dividersElement.findElements('left-divider').firstOrNull),
+        rightDivider: XmlHelper.getElementTextAsBool(
+            dividersElement.findElements('right-divider').firstOrNull),
       );
     }
 
     return SystemLayout(
       systemMargins: margins,
-      systemDistance: XmlHelper.getElementTextAsDouble(element.findElements('system-distance').firstOrNull),
-      topSystemDistance: XmlHelper.getElementTextAsDouble(element.findElements('top-system-distance').firstOrNull),
+      systemDistance: XmlHelper.getElementTextAsDouble(
+          element.findElements('system-distance').firstOrNull),
+      topSystemDistance: XmlHelper.getElementTextAsDouble(
+          element.findElements('top-system-distance').firstOrNull),
       systemDividers: dividers,
     );
   }

--- a/lib/src/parser/xml_helper.dart
+++ b/lib/src/parser/xml_helper.dart
@@ -56,7 +56,8 @@ class XmlHelper {
         }
       } else {
         // Element selection with optional predicate
-        currentContextNode = _findElementFromSegment(currentContextNode, segment);
+        currentContextNode =
+            _findElementFromSegment(currentContextNode, segment);
       }
     }
 
@@ -69,7 +70,8 @@ class XmlHelper {
   /// with an attribute predicate (e.g., 'creator[@type="composer"]').
   ///
   /// Returns the first matching [XmlElement], or `null` if not found.
-  static XmlElement? _findElementFromSegment(XmlElement parent, String segment) {
+  static XmlElement? _findElementFromSegment(
+      XmlElement parent, String segment) {
     final predicateMatch = RegExp(r'(.+?)\[(.+?)\]').firstMatch(segment);
 
     if (predicateMatch != null) {
@@ -82,19 +84,19 @@ class XmlHelper {
       }
 
       // Handle @attribute="value" predicate
-      final attributePredicateMatch = RegExp(r'@(.+?)="(.+?)"').firstMatch(predicate);
+      final attributePredicateMatch =
+          RegExp(r'@(.+?)="(.+?)"').firstMatch(predicate);
       if (attributePredicateMatch != null) {
         final attributeName = attributePredicateMatch.group(1);
         final attributeValue = attributePredicateMatch.group(2);
 
         if (attributeName != null && attributeValue != null) {
           try {
-            return parent
-                .findElements(elementName)
-                .firstWhere(
+            return parent.findElements(elementName).firstWhere(
                   (el) => el.getAttribute(attributeName) == attributeValue,
                 );
-          } catch (e) { // firstWhere throws StateError if no element is found
+          } catch (e) {
+            // firstWhere throws StateError if no element is found
             return null;
           }
         }
@@ -162,7 +164,8 @@ class XmlHelper {
   /// Recognizes "yes" (case-insensitive) as `true` and "no" (case-insensitive)
   /// as `false`. For any other text, or if the element is `null` or its text is empty,
   /// returns the [defaultValue] (which is `false` if not specified).
-  static bool getElementTextAsBool(XmlElement? element, {bool defaultValue = false}) {
+  static bool getElementTextAsBool(XmlElement? element,
+      {bool defaultValue = false}) {
     if (element == null) return defaultValue;
     final text = element.innerText.trim().toLowerCase();
     if (text == 'yes') return true;

--- a/lib/src/parser/xml_helper.dart
+++ b/lib/src/parser/xml_helper.dart
@@ -1,90 +1,117 @@
 import 'package:musicxml_parser/src/exceptions/musicxml_structure_exception.dart';
 import 'package:xml/xml.dart';
 
-/// Helper class for XML operations specific to MusicXML parsing.
+/// Utility class providing helper methods for parsing MusicXML documents.
+///
+/// This class includes functions for common XML operations such as retrieving
+/// element line numbers, finding child elements, and converting element text
+/// to various data types, tailored for the needs of MusicXML parsing.
 class XmlHelper {
-  /// Gets the line number of an XML element, if available.
+  /// Gets the line number of an XML [element], if available from its attributes.
   ///
-  /// Returns -1 if the line number is not available.
+  /// MusicXML elements do not standardly include line numbers. This method
+  /// checks for a non-standard 'line' attribute that might be added by
+  /// pre-processing tools or for debugging.
+  ///
+  /// Returns the line number if found, otherwise -1.
   static int getLineNumber(XmlElement? element) {
     if (element == null) return -1;
 
-    // Check for line number in element attributes
     final lineAttribute = element.getAttribute('line');
     if (lineAttribute != null) {
       final lineNum = int.tryParse(lineAttribute);
       if (lineNum != null) return lineNum;
     }
-
-    // Line number not available
     return -1;
   }
 
-  /// Finds optional text content from an XML element using an XPath-like path.
+  /// Finds the text content of an optional child element specified by a simple [path].
   ///
-  /// [element] - The parent XML element to search from.
-  /// [path] - A simplified XPath-like string (e.g., 'work/work-title').
+  /// The [path] is a '/' separated string representing a sequence of child elements.
+  /// It also supports selecting an attribute using '@attributeName' as the last segment,
+  /// or filtering by an attribute value using 'elementName[@attribute="value"]'.
   ///
-  /// Returns the text content of the found element, or null if not found.
+  /// Example paths:
+  /// - 'work/work-title' (finds `<work-title>` inside `<work>`)
+  /// - 'identification/creator[@type="composer"]' (finds `<creator type="composer">` inside `<identification>`)
+  /// - 'attributes/@version' (gets the 'version' attribute of the `<attributes>` element)
+  ///
+  /// Returns the trimmed text content of the found element or attribute, or `null` if not found.
   static String? findOptionalTextElement(XmlElement element, String path) {
-    XmlElement? current = element;
-    final parts = path.split('/');
+    XmlElement? currentContextNode = element;
+    final pathSegments = path.split('/');
 
-    for (final part in parts) {
-      if (current == null) return null;
+    for (int i = 0; i < pathSegments.length; i++) {
+      final segment = pathSegments[i];
+      if (currentContextNode == null) return null;
 
-      // Handle attribute selector
-      if (part.startsWith('@')) {
-        final attrName = part.substring(1);
-        return current.getAttribute(attrName);
-      }
-
-      // Handle predicates like element[@attr="value"]
-      if (part.contains('[') && part.contains(']')) {
-        final match = RegExp(r'(.+?)\[(.+?)\]').firstMatch(part);
-        if (match != null) {
-          final elementName = match.group(1);
-          final predicate = match.group(2);
-
-          if (elementName != null && predicate != null) {
-            // Handle @attr="value" predicate
-            if (predicate.startsWith('@')) {
-              final attrMatch = RegExp(r'@(.+?)="(.+?)"').firstMatch(predicate);
-              if (attrMatch != null) {
-                final attrName = attrMatch.group(1);
-                final attrValue = attrMatch.group(2);
-
-                if (attrName != null && attrValue != null) {
-                  final elements = current.findElements(elementName);
-                  XmlElement? found = null;
-                  for (var e in elements) {
-                    if (e.getAttribute(attrName) == attrValue) {
-                      found = e;
-                      break;
-                    }
-                  }
-                  current = found;
-                  continue;
-                }
-              }
-            }
-          }
+      if (segment.startsWith('@')) {
+        // Attribute selection should be the last segment
+        if (i == pathSegments.length - 1) {
+          final attributeName = segment.substring(1);
+          return currentContextNode.getAttribute(attributeName);
+        } else {
+          // Attribute selection in the middle of a path is not supported by this simplified helper
+          return null;
         }
-
-        // Regular element name
-        current = current.findElements(part).firstOrNull;
       } else {
-        // Regular element name
-        current = current.findElements(part).firstOrNull;
+        // Element selection with optional predicate
+        currentContextNode = _findElementFromSegment(currentContextNode, segment);
       }
     }
 
-    return current?.innerText.trim();
+    return currentContextNode?.innerText.trim();
   }
 
-  /// Finds and returns a required element.
+  /// Internal helper to find a child element based on a [segment] name, handling predicates.
   ///
-  /// Throws [MusicXmlStructureException] if the element is not found.
+  /// A [segment] can be a simple element name (e.g., "note") or an element name
+  /// with an attribute predicate (e.g., 'creator[@type="composer"]').
+  ///
+  /// Returns the first matching [XmlElement], or `null` if not found.
+  static XmlElement? _findElementFromSegment(XmlElement parent, String segment) {
+    final predicateMatch = RegExp(r'(.+?)\[(.+?)\]').firstMatch(segment);
+
+    if (predicateMatch != null) {
+      final elementName = predicateMatch.group(1);
+      final predicate = predicateMatch.group(2);
+
+      if (elementName == null || predicate == null) {
+        // Malformed segment (e.g., "name[]" or "[]value"), treat as simple element name
+        return parent.findElements(segment).firstOrNull;
+      }
+
+      // Handle @attribute="value" predicate
+      final attributePredicateMatch = RegExp(r'@(.+?)="(.+?)"').firstMatch(predicate);
+      if (attributePredicateMatch != null) {
+        final attributeName = attributePredicateMatch.group(1);
+        final attributeValue = attributePredicateMatch.group(2);
+
+        if (attributeName != null && attributeValue != null) {
+          try {
+            return parent
+                .findElements(elementName)
+                .firstWhere(
+                  (el) => el.getAttribute(attributeName) == attributeValue,
+                );
+          } catch (e) { // firstWhere throws StateError if no element is found
+            return null;
+          }
+        }
+      }
+      // Fallback for unhandled or malformed predicate: find first element by name if any
+      return parent.findElements(elementName).firstOrNull;
+    } else {
+      // Simple element name, no predicate
+      return parent.findElements(segment).firstOrNull;
+    }
+  }
+
+  /// Finds and returns a required child [XmlElement] with the given [name].
+  ///
+  /// Throws a [MusicXmlStructureException] if the element is not found.
+  /// The [requiredElement] parameter can be used to specify a more descriptive
+  /// name in the exception message if [name] is too generic.
   static XmlElement getRequiredElement(
     XmlElement parent,
     String name, {
@@ -93,58 +120,53 @@ class XmlHelper {
     final elements = parent.findElements(name);
     if (elements.isEmpty) {
       throw MusicXmlStructureException(
-        'Required element $name not found',
+        'Required element <${requiredElement ?? name}> not found as a child of <${parent.name.local}>.',
         requiredElement: requiredElement ?? name,
+        parentElement: parent.name.local,
         line: getLineNumber(parent),
       );
     }
     return elements.first;
   }
 
-  /// Finds and returns an optional element.
+  /// Finds and returns an optional child [XmlElement] with the given [name].
   ///
-  /// Returns null if the element is not found.
+  /// Returns `null` if the element is not found.
   static XmlElement? findOptionalElement(XmlElement parent, String name) {
     final elements = parent.findElements(name);
     return elements.isNotEmpty ? elements.first : null;
   }
 
-  /// Gets the text content of an element as an integer.
+  /// Gets the trimmed text content of an [element] and parses it as an integer.
   ///
-  /// Returns null if the element is not found or the content is not a valid integer.
+  /// Returns the integer value, or `null` if the [element] is `null`,
+  /// its text is empty, or not a valid integer.
   static int? getElementTextAsInt(XmlElement? element) {
     if (element == null) return null;
-
     final text = element.innerText.trim();
     return int.tryParse(text);
   }
 
-  /// Gets the text content of an element as a double.
+  /// Gets the trimmed text content of an [element] and parses it as a double.
   ///
-  /// Returns null if the element is not found or the content is not a valid double.
+  /// Returns the double value, or `null` if the [element] is `null`,
+  /// its text is empty, or not a valid double.
   static double? getElementTextAsDouble(XmlElement? element) {
     if (element == null) return null;
-
     final text = element.innerText.trim();
     return double.tryParse(text);
   }
 
-  /// Gets the text content of an element as a boolean.
+  /// Gets the trimmed text content of an [element] and interprets it as a boolean.
   ///
-  /// Returns `true` if the text is "yes" (case-insensitive).
-  /// Returns `false` if the text is "no" (case-insensitive).
-  /// Returns `defaultValue` (which is `false` if not specified) for any other text,
-  /// or if the element is null or its text is empty.
+  /// Recognizes "yes" (case-insensitive) as `true` and "no" (case-insensitive)
+  /// as `false`. For any other text, or if the element is `null` or its text is empty,
+  /// returns the [defaultValue] (which is `false` if not specified).
   static bool getElementTextAsBool(XmlElement? element, {bool defaultValue = false}) {
     if (element == null) return defaultValue;
-
     final text = element.innerText.trim().toLowerCase();
-    if (text == 'yes') {
-      return true;
-    }
-    if (text == 'no') {
-      return false;
-    }
+    if (text == 'yes') return true;
+    if (text == 'no') return false;
     return defaultValue;
   }
 }

--- a/lib/src/utils/warning_system.dart
+++ b/lib/src/utils/warning_system.dart
@@ -307,4 +307,5 @@ class WarningCategories {
   static const String notation = 'notation';
   static const String performance = 'performance';
   static const String compatibility = 'compatibility';
+  static const String noteDivisions = 'note_divisions';
 }

--- a/lib/src/utils/warning_system.dart
+++ b/lib/src/utils/warning_system.dart
@@ -220,7 +220,7 @@ class WarningSystem {
   }
 
   /// Clears all warnings.
-  void clear() => _warnings.clear();
+  void clearWarnings() => _warnings.clear();
 
   /// Checks if there are any warnings.
   bool get hasWarnings => _warnings.isNotEmpty;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   archive: ^4.0.7
   dart_console: ^4.1.2
 
+  collection: any
 dev_dependencies:
   build_runner: ^2.4.7
   lint: ^2.3.0

--- a/test/models/articulation_test.dart
+++ b/test/models/articulation_test.dart
@@ -20,8 +20,10 @@ void main() {
     group('equality and hashCode', () {
       const art1 = Articulation(type: 'staccato', placement: 'above');
       const art2 = Articulation(type: 'staccato', placement: 'above');
-      const art3 = Articulation(type: 'accent', placement: 'above'); // Different type
-      const art4 = Articulation(type: 'staccato', placement: 'below'); // Different placement
+      const art3 =
+          Articulation(type: 'accent', placement: 'above'); // Different type
+      const art4 = Articulation(
+          type: 'staccato', placement: 'below'); // Different placement
       const art5 = Articulation(type: 'staccato'); // Null placement
 
       test('instances with same values are equal and have same hashCode', () {
@@ -52,12 +54,14 @@ void main() {
     group('toString representation', () {
       test('includes all fields when present', () {
         const articulation = Articulation(type: 'accent', placement: 'below');
-        expect(articulation.toString(), equals('Articulation{type: accent, placement: below}'));
+        expect(articulation.toString(),
+            equals('Articulation{type: accent, placement: below}'));
       });
 
       test('omits placement when null', () {
         const articulation = Articulation(type: 'strong-accent');
-        expect(articulation.toString(), equals('Articulation{type: strong-accent}'));
+        expect(articulation.toString(),
+            equals('Articulation{type: strong-accent}'));
       });
     });
   });

--- a/test/models/barline_test.dart
+++ b/test/models/barline_test.dart
@@ -27,12 +27,36 @@ void main() {
     });
 
     group('equality and hashCode', () {
-      const b1 = Barline(location: 'right', barStyle: 'light-heavy', repeatDirection: 'backward', times: 2);
-      const b2 = Barline(location: 'right', barStyle: 'light-heavy', repeatDirection: 'backward', times: 2);
-      const b3 = Barline(location: 'left', barStyle: 'light-heavy', repeatDirection: 'backward', times: 2); // diff location
-      const b4 = Barline(location: 'right', barStyle: 'light-light', repeatDirection: 'backward', times: 2); // diff barStyle
-      const b5 = Barline(location: 'right', barStyle: 'light-heavy', repeatDirection: 'forward', times: 2); // diff repeatDirection
-      const b6 = Barline(location: 'right', barStyle: 'light-heavy', repeatDirection: 'backward', times: 3); // diff times
+      const b1 = Barline(
+          location: 'right',
+          barStyle: 'light-heavy',
+          repeatDirection: 'backward',
+          times: 2);
+      const b2 = Barline(
+          location: 'right',
+          barStyle: 'light-heavy',
+          repeatDirection: 'backward',
+          times: 2);
+      const b3 = Barline(
+          location: 'left',
+          barStyle: 'light-heavy',
+          repeatDirection: 'backward',
+          times: 2); // diff location
+      const b4 = Barline(
+          location: 'right',
+          barStyle: 'light-light',
+          repeatDirection: 'backward',
+          times: 2); // diff barStyle
+      const b5 = Barline(
+          location: 'right',
+          barStyle: 'light-heavy',
+          repeatDirection: 'forward',
+          times: 2); // diff repeatDirection
+      const b6 = Barline(
+          location: 'right',
+          barStyle: 'light-heavy',
+          repeatDirection: 'backward',
+          times: 3); // diff times
       const b7 = Barline(); // all null
 
       test('instances with same values are equal and have same hashCode', () {
@@ -70,8 +94,15 @@ void main() {
 
     group('toString representation', () {
       test('includes all fields when present', () {
-        const barline = Barline(location: 'right', barStyle: 'light-heavy', repeatDirection: 'backward', times: 2);
-        expect(barline.toString(), equals('Barline{location: right, barStyle: light-heavy, repeatDirection: backward, times: 2}'));
+        const barline = Barline(
+            location: 'right',
+            barStyle: 'light-heavy',
+            repeatDirection: 'backward',
+            times: 2);
+        expect(
+            barline.toString(),
+            equals(
+                'Barline{location: right, barStyle: light-heavy, repeatDirection: backward, times: 2}'));
       });
 
       test('omits fields when null', () {

--- a/test/models/credit_test.dart
+++ b/test/models/credit_test.dart
@@ -15,7 +15,9 @@ void main() {
         expect(credit.creditWords, equals(['John Doe']));
       });
 
-      test('properties can be null (except creditWords which defaults to empty)', () {
+      test(
+          'properties can be null (except creditWords which defaults to empty)',
+          () {
         const credit = Credit();
         expect(credit.page, isNull);
         expect(credit.creditType, isNull);
@@ -29,12 +31,24 @@ void main() {
     });
 
     group('equality and hashCode', () {
-      const c1 = Credit(page: 1, creditType: 'title', creditWords: ['My Score']);
-      const c2 = Credit(page: 1, creditType: 'title', creditWords: ['My Score']);
-      const c3 = Credit(page: 2, creditType: 'title', creditWords: ['My Score']); // diff page
-      const c4 = Credit(page: 1, creditType: 'subtitle', creditWords: ['My Score']); // diff type
-      const c5 = Credit(page: 1, creditType: 'title', creditWords: ['Another Score']); // diff words
-      const c6 = Credit(page: 1, creditType: 'title', creditWords: ['My', 'Score']); // diff words list structure
+      const c1 =
+          Credit(page: 1, creditType: 'title', creditWords: ['My Score']);
+      const c2 =
+          Credit(page: 1, creditType: 'title', creditWords: ['My Score']);
+      const c3 = Credit(
+          page: 2, creditType: 'title', creditWords: ['My Score']); // diff page
+      const c4 = Credit(
+          page: 1,
+          creditType: 'subtitle',
+          creditWords: ['My Score']); // diff type
+      const c5 = Credit(
+          page: 1,
+          creditType: 'title',
+          creditWords: ['Another Score']); // diff words
+      const c6 = Credit(
+          page: 1,
+          creditType: 'title',
+          creditWords: ['My', 'Score']); // diff words list structure
       const c7 = Credit(); // all optional null, words empty
 
       test('instances with same values are equal and have same hashCode', () {
@@ -59,13 +73,14 @@ void main() {
 
       test('instances with different creditWords are not equal', () {
         expect(c1, isNot(equals(c5)));
-        expect(c1, isNot(equals(c6))); // c1 has ['My Score'], c6 has ['My', 'Score']
+        expect(c1,
+            isNot(equals(c6))); // c1 has ['My Score'], c6 has ['My', 'Score']
       });
 
       test('instance with values vs all default/empty is not equal', () {
         expect(c1, isNot(equals(c7)));
       });
-       test('instances with different numbers of creditWords are not equal', () {
+      test('instances with different numbers of creditWords are not equal', () {
         const credit_multi_words = Credit(creditWords: ['Word1', 'Word2']);
         const credit_single_word = Credit(creditWords: ['Word1']);
         expect(credit_multi_words, isNot(equals(credit_single_word)));
@@ -74,18 +89,27 @@ void main() {
 
     group('toString representation', () {
       test('includes all fields when present', () {
-        const credit = Credit(page: 1, creditType: 'arranger', creditWords: ['Arr. By Me']);
+        const credit = Credit(
+            page: 1, creditType: 'arranger', creditWords: ['Arr. By Me']);
         // Based on Credit model's toString: Credit{page: 1, creditType: "arranger", creditWords: "Arr. By Me"}
-        expect(credit.toString(), equals('Credit{page: 1, creditType: "arranger", creditWords: "Arr. By Me"}'));
+        expect(
+            credit.toString(),
+            equals(
+                'Credit{page: 1, creditType: "arranger", creditWords: "Arr. By Me"}'));
       });
 
       test('handles multiple creditWords', () {
-        const credit = Credit(creditType: 'title', creditWords: ['Main Title', 'Subtitle']);
-        expect(credit.toString(), equals('Credit{creditType: "title", creditWords: "Main Title", "Subtitle"}'));
+        const credit = Credit(
+            creditType: 'title', creditWords: ['Main Title', 'Subtitle']);
+        expect(
+            credit.toString(),
+            equals(
+                'Credit{creditType: "title", creditWords: "Main Title", "Subtitle"}'));
       });
 
       test('omits fields when null/empty', () {
-        const credit = Credit(creditType: 'dedication'); // page null, creditWords empty
+        const credit =
+            Credit(creditType: 'dedication'); // page null, creditWords empty
         expect(credit.toString(), equals('Credit{creditType: "dedication"}'));
       });
 

--- a/test/models/ending_test.dart
+++ b/test/models/ending_test.dart
@@ -22,21 +22,23 @@ void main() {
     group('equality and hashCode', () {
       const e1 = Ending(number: '1', type: 'start', printObject: 'yes');
       const e2 = Ending(number: '1', type: 'start', printObject: 'yes');
-      const e3 = Ending(number: '2', type: 'start', printObject: 'yes'); // diff number
-      const e4 = Ending(number: '1', type: 'stop', printObject: 'yes'); // diff type
-      const e5 = Ending(number: '1', type: 'start', printObject: 'no'); // diff printObject
+      const e3 =
+          Ending(number: '2', type: 'start', printObject: 'yes'); // diff number
+      const e4 =
+          Ending(number: '1', type: 'stop', printObject: 'yes'); // diff type
+      const e5 = Ending(
+          number: '1', type: 'start', printObject: 'no'); // diff printObject
 
       // Test constructor default for printObject
       const e_default_po1 = Ending(number: '1', type: 'start');
       const e_default_po2 = Ending(number: '1', type: 'start');
-
 
       test('instances with same values are equal and have same hashCode', () {
         expect(e1, equals(e2));
         expect(e1.hashCode, equals(e2.hashCode));
       });
 
-      test('instances using default printObject are equal',(){
+      test('instances using default printObject are equal', () {
         expect(e1, equals(e_default_po1));
         expect(e1.hashCode, equals(e_default_po1.hashCode));
         expect(e_default_po1, equals(e_default_po2));
@@ -58,12 +60,15 @@ void main() {
 
     group('toString representation', () {
       test('includes all fields, printObject shown if not default', () {
-        const ending1 = Ending(number: '1, 3', type: 'discontinue', printObject: 'no');
-        expect(ending1.toString(), equals('Ending{number: 1, 3, type: discontinue, printObject: no}'));
+        const ending1 =
+            Ending(number: '1, 3', type: 'discontinue', printObject: 'no');
+        expect(ending1.toString(),
+            equals('Ending{number: 1, 3, type: discontinue, printObject: no}'));
       });
 
       test('omits printObject when it is default "yes"', () {
-        const ending2 = Ending(number: '2', type: 'stop'); // printObject defaults to "yes"
+        const ending2 =
+            Ending(number: '2', type: 'stop'); // printObject defaults to "yes"
         expect(ending2.toString(), equals('Ending{number: 2, type: stop}'));
 
         const ending3 = Ending(number: '2', type: 'stop', printObject: 'yes');

--- a/test/models/note_test.dart
+++ b/test/models/note_test.dart
@@ -1,7 +1,4 @@
 import 'package:musicxml_parser/musicxml_parser.dart';
-import 'package:musicxml_parser/src/models/pitch.dart';
-import 'package:musicxml_parser/src/models/duration.dart';
-import 'package:musicxml_parser/src/exceptions/musicxml_validation_exception.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -55,39 +52,56 @@ void main() {
     });
 
     group('equality and hashCode', () {
-      test('notes with same properties (including dots) are equal and have same hashCode', () {
-        final note1 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
-        final note2 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+      test(
+          'notes with same properties (including dots) are equal and have same hashCode',
+          () {
+        final note1 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note2 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
         expect(note1 == note2, isTrue);
         expect(note1.hashCode == note2.hashCode, isTrue);
       });
 
       test('notes with different dots are not equal', () {
-        final note1 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
-        final note2 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 2);
+        final note1 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note2 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 2);
         expect(note1 == note2, isFalse);
       });
 
       test('notes with null dots vs non-null dots are not equal', () {
-        final note1 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: null);
-        final note2 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note1 = Note(
+            pitch: pitchC4,
+            duration: durationQuarter,
+            isRest: false,
+            dots: null);
+        final note2 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
         expect(note1 == note2, isFalse);
       });
 
       test('notes with different pitch are not equal when dots are same', () {
-        final note1 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
-        final note2 = Note(pitch: pitchG4, duration: durationQuarter, isRest: false, dots: 1);
+        final note1 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note2 = Note(
+            pitch: pitchG4, duration: durationQuarter, isRest: false, dots: 1);
         expect(note1 == note2, isFalse);
       });
 
-      test('notes with different duration are not equal when dots are same', () {
-        final note1 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
-        final note2 = Note(pitch: pitchC4, duration: durationHalf, isRest: false, dots: 1);
+      test('notes with different duration are not equal when dots are same',
+          () {
+        final note1 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note2 = Note(
+            pitch: pitchC4, duration: durationHalf, isRest: false, dots: 1);
         expect(note1 == note2, isFalse);
       });
 
       test('rest vs pitch note with same duration and dots are not equal', () {
-        final note1 = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note1 = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
         final note2 = Note(duration: durationQuarter, isRest: true, dots: 1);
         expect(note1 == note2, isFalse);
       });
@@ -95,87 +109,107 @@ void main() {
 
     group('toString representation', () {
       test('toString includes dot information for single dot', () {
-        final note = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
+        final note = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 1);
         expect(note.toString(), contains('dots: 1'));
       });
 
       test('toString includes dot information for multiple dots', () {
-        final note = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 2);
+        final note = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 2);
         expect(note.toString(), contains('dots: 2'));
       });
 
       test('toString does not mention dots if dots is null', () {
-        final note = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: null);
+        final note = Note(
+            pitch: pitchC4,
+            duration: durationQuarter,
+            isRest: false,
+            dots: null);
         expect(note.toString(), isNot(contains('dots:')));
       });
 
       test('toString does not mention dots if dots is 0', () {
         // Based on the implementation: "if (dots != null && dots! > 0)"
-        final note = Note(pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 0);
+        final note = Note(
+            pitch: pitchC4, duration: durationQuarter, isRest: false, dots: 0);
         expect(note.toString(), isNot(contains('dots:')));
       });
 
       test('toString for rest with dots', () {
         final rest = Note(duration: durationQuarter, isRest: true, dots: 1);
-        expect(rest.toString(), contains('Rest{duration: Duration{value: 480, divisions: 480}, dots: 1}'));
+        expect(
+            rest.toString(),
+            contains(
+                'Rest{duration: Duration{value: 480, divisions: 480}, dots: 1}'));
       });
 
-       test('toString for rest with no dots', () {
+      test('toString for rest with no dots', () {
         final rest = Note(duration: durationQuarter, isRest: true, dots: null);
-        expect(rest.toString(), equals('Rest{duration: Duration{value: 480, divisions: 480}}'));
+        expect(rest.toString(),
+            equals('Rest{duration: Duration{value: 480, divisions: 480}}'));
       });
     });
 
     group('Note.validated factory', () {
       test('Note.validated allows positive dots', () {
         expect(
-            () => Note.validated(pitch: pitchC4, duration: durationQuarter, dots: 1),
+            () => Note.validated(
+                pitch: pitchC4, duration: durationQuarter, dots: 1),
             returnsNormally);
-        final note = Note.validated(pitch: pitchC4, duration: durationQuarter, dots: 1);
+        final note =
+            Note.validated(pitch: pitchC4, duration: durationQuarter, dots: 1);
         expect(note.dots, equals(1));
       });
 
       test('Note.validated allows null dots', () {
         expect(
-            () => Note.validated(pitch: pitchC4, duration: durationQuarter, dots: null),
+            () => Note.validated(
+                pitch: pitchC4, duration: durationQuarter, dots: null),
             returnsNormally);
-        final note = Note.validated(pitch: pitchC4, duration: durationQuarter, dots: null);
+        final note = Note.validated(
+            pitch: pitchC4, duration: durationQuarter, dots: null);
         expect(note.dots, isNull);
       });
 
       test('Note.validated allows zero dots', () {
         expect(
-            () => Note.validated(pitch: pitchC4, duration: durationQuarter, dots: 0),
+            () => Note.validated(
+                pitch: pitchC4, duration: durationQuarter, dots: 0),
             returnsNormally);
-        final note = Note.validated(pitch: pitchC4, duration: durationQuarter, dots: 0);
+        final note =
+            Note.validated(pitch: pitchC4, duration: durationQuarter, dots: 0);
         expect(note.dots, equals(0));
       });
 
       test('Note.validated throws for negative dots', () {
         expect(
-            () => Note.validated(pitch: pitchC4, duration: durationQuarter, dots: -1),
+            () => Note.validated(
+                pitch: pitchC4, duration: durationQuarter, dots: -1),
             throwsA(isA<MusicXmlValidationException>()
-                .having((e) => e.message, 'message', 'Note dots must be non-negative, got -1')
-                .having((e) => e.rule, 'rule', 'note_dots_validation')
-            ));
+                .having((e) => e.message, 'message',
+                    'Note dots must be non-negative, got -1')
+                .having((e) => e.rule, 'rule', 'note_dots_validation')));
       });
 
       // Test for rest with dots using validated factory
       test('Note.validated allows dots for rests', () {
-         expect(
-            () => Note.validated(isRest: true, duration: durationQuarter, dots: 1),
+        expect(
+            () => Note.validated(
+                isRest: true, duration: durationQuarter, dots: 1),
             returnsNormally);
-        final rest = Note.validated(isRest: true, duration: durationQuarter, dots: 1);
+        final rest =
+            Note.validated(isRest: true, duration: durationQuarter, dots: 1);
         expect(rest.isRest, isTrue);
         expect(rest.dots, equals(1));
       });
 
       test('Note.validated throws for negative dots on a rest', () {
         expect(
-            () => Note.validated(isRest: true, duration: durationQuarter, dots: -1),
-            throwsA(isA<MusicXmlValidationException>()
-                .having((e) => e.message, 'message', 'Note dots must be non-negative, got -1')
-            ));
+            () => Note.validated(
+                isRest: true, duration: durationQuarter, dots: -1),
+            throwsA(isA<MusicXmlValidationException>().having((e) => e.message,
+                'message', 'Note dots must be non-negative, got -1')));
       });
     });
   });

--- a/test/models/slur_test.dart
+++ b/test/models/slur_test.dart
@@ -29,9 +29,12 @@ void main() {
     group('equality and hashCode', () {
       const slur1 = Slur(type: 'start', number: 1, placement: 'above');
       const slur2 = Slur(type: 'start', number: 1, placement: 'above');
-      const slur3 = Slur(type: 'stop', number: 1, placement: 'above'); // Different type
-      const slur4 = Slur(type: 'start', number: 2, placement: 'above'); // Different number
-      const slur5 = Slur(type: 'start', number: 1, placement: 'below'); // Different placement
+      const slur3 =
+          Slur(type: 'stop', number: 1, placement: 'above'); // Different type
+      const slur4 = Slur(
+          type: 'start', number: 2, placement: 'above'); // Different number
+      const slur5 = Slur(
+          type: 'start', number: 1, placement: 'below'); // Different placement
       const slur6 = Slur(type: 'start', number: 1); // Null placement
 
       test('instances with same values are equal and have same hashCode', () {
@@ -54,7 +57,7 @@ void main() {
       test('instances with null vs non-null placement are not equal', () {
         expect(slur1, isNot(equals(slur6)));
       });
-       test('instances with different null placements are equal', () {
+      test('instances with different null placements are equal', () {
         const s1 = Slur(type: 'start', number: 1);
         const s2 = Slur(type: 'start', number: 1);
         expect(s1, equals(s2));
@@ -65,14 +68,15 @@ void main() {
     group('toString representation', () {
       test('includes all fields when present', () {
         const slur = Slur(type: 'start', number: 1, placement: 'above');
-        expect(slur.toString(), equals('Slur{type: start, number: 1, placement: above}'));
+        expect(slur.toString(),
+            equals('Slur{type: start, number: 1, placement: above}'));
       });
 
       test('omits placement when null', () {
         const slur = Slur(type: 'start', number: 2);
         expect(slur.toString(), equals('Slur{type: start, number: 2}'));
       });
-       test('handles default number correctly in toString', () {
+      test('handles default number correctly in toString', () {
         const slur = Slur(type: 'stop');
         expect(slur.toString(), equals('Slur{type: stop, number: 1}'));
       });

--- a/test/models/tie_test.dart
+++ b/test/models/tie_test.dart
@@ -21,7 +21,8 @@ void main() {
       const tie1 = Tie(type: 'start', placement: 'above');
       const tie2 = Tie(type: 'start', placement: 'above');
       const tie3 = Tie(type: 'stop', placement: 'above'); // Different type
-      const tie4 = Tie(type: 'start', placement: 'below'); // Different placement
+      const tie4 =
+          Tie(type: 'start', placement: 'below'); // Different placement
       const tie5 = Tie(type: 'start'); // Null placement
 
       test('instances with same values are equal and have same hashCode', () {

--- a/test/models/time_modification_test.dart
+++ b/test/models/time_modification_test.dart
@@ -32,11 +32,29 @@ void main() {
     });
 
     group('equality and hashCode', () {
-      const tm1 = TimeModification(actualNotes: 3, normalNotes: 2, normalType: 'eighth', normalDotCount: 0);
-      const tm2 = TimeModification(actualNotes: 3, normalNotes: 2, normalType: 'eighth', normalDotCount: 0);
-      const tm3 = TimeModification(actualNotes: 5, normalNotes: 4, normalType: 'quarter'); // Different actual/normal notes
-      const tm4 = TimeModification(actualNotes: 3, normalNotes: 2, normalType: 'quarter'); // Different normalType
-      const tm5 = TimeModification(actualNotes: 3, normalNotes: 2, normalType: 'eighth', normalDotCount: 1); // Different normalDotCount
+      const tm1 = TimeModification(
+          actualNotes: 3,
+          normalNotes: 2,
+          normalType: 'eighth',
+          normalDotCount: 0);
+      const tm2 = TimeModification(
+          actualNotes: 3,
+          normalNotes: 2,
+          normalType: 'eighth',
+          normalDotCount: 0);
+      const tm3 = TimeModification(
+          actualNotes: 5,
+          normalNotes: 4,
+          normalType: 'quarter'); // Different actual/normal notes
+      const tm4 = TimeModification(
+          actualNotes: 3,
+          normalNotes: 2,
+          normalType: 'quarter'); // Different normalType
+      const tm5 = TimeModification(
+          actualNotes: 3,
+          normalNotes: 2,
+          normalType: 'eighth',
+          normalDotCount: 1); // Different normalDotCount
 
       test('instances with same values are equal and have same hashCode', () {
         expect(tm1, equals(tm2));
@@ -48,7 +66,8 @@ void main() {
       });
 
       test('instances with different normalNotes are not equal', () {
-         const tm_diff_normal = TimeModification(actualNotes: 3, normalNotes: 3, normalType: 'eighth');
+        const tm_diff_normal = TimeModification(
+            actualNotes: 3, normalNotes: 3, normalType: 'eighth');
         expect(tm1, isNot(equals(tm_diff_normal)));
       });
 
@@ -61,8 +80,14 @@ void main() {
       });
 
       test('instances with null vs non-null optional fields are not equal', () {
-        const tm_null_type = TimeModification(actualNotes: 3, normalNotes: 2, normalDotCount: 0); // normalType is null
-        const tm_null_dots = TimeModification(actualNotes: 3, normalNotes: 2, normalType: 'eighth'); // normalDotCount is null
+        const tm_null_type = TimeModification(
+            actualNotes: 3,
+            normalNotes: 2,
+            normalDotCount: 0); // normalType is null
+        const tm_null_dots = TimeModification(
+            actualNotes: 3,
+            normalNotes: 2,
+            normalType: 'eighth'); // normalDotCount is null
 
         // tm1 has normalType: 'eighth', normalDotCount: 0
         // tm_null_type has normalType: null, normalDotCount: 0
@@ -85,7 +110,10 @@ void main() {
         expect(tm.toString(), contains('normalNotes: 2'));
         expect(tm.toString(), contains('normalType: eighth'));
         expect(tm.toString(), contains('normalDotCount: 1'));
-        expect(tm.toString(), equals('TimeModification{actualNotes: 3, normalNotes: 2, normalType: eighth, normalDotCount: 1}'));
+        expect(
+            tm.toString(),
+            equals(
+                'TimeModification{actualNotes: 3, normalNotes: 2, normalType: eighth, normalDotCount: 1}'));
       });
 
       test('omits optional fields when null', () {
@@ -94,25 +122,38 @@ void main() {
         expect(tm.toString(), contains('normalNotes: 2'));
         expect(tm.toString(), isNot(contains('normalType:')));
         expect(tm.toString(), isNot(contains('normalDotCount:')));
-        expect(tm.toString(), equals('TimeModification{actualNotes: 3, normalNotes: 2}'));
+        expect(tm.toString(),
+            equals('TimeModification{actualNotes: 3, normalNotes: 2}'));
       });
 
-      test('omits only normalDotCount when normalType is present and normalDotCount is null', () {
-        const tm = TimeModification(actualNotes: 3, normalNotes: 2, normalType: 'quarter');
+      test(
+          'omits only normalDotCount when normalType is present and normalDotCount is null',
+          () {
+        const tm = TimeModification(
+            actualNotes: 3, normalNotes: 2, normalType: 'quarter');
         expect(tm.toString(), contains('actualNotes: 3'));
         expect(tm.toString(), contains('normalNotes: 2'));
         expect(tm.toString(), contains('normalType: quarter'));
         expect(tm.toString(), isNot(contains('normalDotCount:')));
-        expect(tm.toString(), equals('TimeModification{actualNotes: 3, normalNotes: 2, normalType: quarter}'));
+        expect(
+            tm.toString(),
+            equals(
+                'TimeModification{actualNotes: 3, normalNotes: 2, normalType: quarter}'));
       });
 
-      test('omits only normalType when normalDotCount is present and normalType is null', () {
-        const tm = TimeModification(actualNotes: 3, normalNotes: 2, normalDotCount: 0);
+      test(
+          'omits only normalType when normalDotCount is present and normalType is null',
+          () {
+        const tm =
+            TimeModification(actualNotes: 3, normalNotes: 2, normalDotCount: 0);
         expect(tm.toString(), contains('actualNotes: 3'));
         expect(tm.toString(), contains('normalNotes: 2'));
         expect(tm.toString(), isNot(contains('normalType:')));
         expect(tm.toString(), contains('normalDotCount: 0'));
-        expect(tm.toString(), equals('TimeModification{actualNotes: 3, normalNotes: 2, normalDotCount: 0}'));
+        expect(
+            tm.toString(),
+            equals(
+                'TimeModification{actualNotes: 3, normalNotes: 2, normalDotCount: 0}'));
       });
     });
 
@@ -120,11 +161,16 @@ void main() {
       test('allows valid values', () {
         expect(
             () => TimeModification.validated(
-                actualNotes: 3, normalNotes: 2, normalType: 'eighth', normalDotCount: 1),
+                actualNotes: 3,
+                normalNotes: 2,
+                normalType: 'eighth',
+                normalDotCount: 1),
             returnsNormally);
         expect(
             () => TimeModification.validated(
-                actualNotes: 3, normalNotes: 2, normalDotCount: 0), // normalDotCount = 0 is valid
+                actualNotes: 3,
+                normalNotes: 2,
+                normalDotCount: 0), // normalDotCount = 0 is valid
             returnsNormally);
         expect(
             () => TimeModification.validated(
@@ -135,37 +181,41 @@ void main() {
       test('throws for non-positive actualNotes', () {
         expect(
             () => TimeModification.validated(actualNotes: 0, normalNotes: 2),
-            throwsA(isA<MusicXmlValidationException>().having(
-                (e) => e.rule, 'rule', 'time_modification_actual_notes_positive')));
+            throwsA(isA<MusicXmlValidationException>().having((e) => e.rule,
+                'rule', 'time_modification_actual_notes_positive')));
         expect(
             () => TimeModification.validated(actualNotes: -1, normalNotes: 2),
-            throwsA(isA<MusicXmlValidationException>().having(
-                (e) => e.rule, 'rule', 'time_modification_actual_notes_positive')));
+            throwsA(isA<MusicXmlValidationException>().having((e) => e.rule,
+                'rule', 'time_modification_actual_notes_positive')));
       });
 
       test('throws for non-positive normalNotes', () {
         expect(
             () => TimeModification.validated(actualNotes: 3, normalNotes: 0),
-            throwsA(isA<MusicXmlValidationException>().having(
-                (e) => e.rule, 'rule', 'time_modification_normal_notes_positive')));
+            throwsA(isA<MusicXmlValidationException>().having((e) => e.rule,
+                'rule', 'time_modification_normal_notes_positive')));
         expect(
             () => TimeModification.validated(actualNotes: 3, normalNotes: -1),
-            throwsA(isA<MusicXmlValidationException>().having(
-                (e) => e.rule, 'rule', 'time_modification_normal_notes_positive')));
+            throwsA(isA<MusicXmlValidationException>().having((e) => e.rule,
+                'rule', 'time_modification_normal_notes_positive')));
       });
 
       test('throws for negative normalDotCount if specified', () {
         expect(
-            () => TimeModification.validated(actualNotes: 3, normalNotes: 2, normalDotCount: -1),
-            throwsA(isA<MusicXmlValidationException>().having(
-                (e) => e.rule, 'rule', 'time_modification_normal_dot_count_non_negative')));
+            () => TimeModification.validated(
+                actualNotes: 3, normalNotes: 2, normalDotCount: -1),
+            throwsA(isA<MusicXmlValidationException>().having((e) => e.rule,
+                'rule', 'time_modification_normal_dot_count_non_negative')));
       });
 
-      test('allows normalDotCount to be null or 0 and sets value correctly', () {
-         final tmNull = TimeModification.validated(actualNotes: 3, normalNotes: 2, normalDotCount: null);
-         expect(tmNull.normalDotCount, isNull);
-         final tmZero = TimeModification.validated(actualNotes: 3, normalNotes: 2, normalDotCount: 0);
-         expect(tmZero.normalDotCount, 0);
+      test('allows normalDotCount to be null or 0 and sets value correctly',
+          () {
+        final tmNull = TimeModification.validated(
+            actualNotes: 3, normalNotes: 2, normalDotCount: null);
+        expect(tmNull.normalDotCount, isNull);
+        final tmZero = TimeModification.validated(
+            actualNotes: 3, normalNotes: 2, normalDotCount: 0);
+        expect(tmZero.normalDotCount, 0);
       });
     });
   });

--- a/test/parser/enhanced_musicxml_parser_test.dart
+++ b/test/parser/enhanced_musicxml_parser_test.dart
@@ -293,6 +293,31 @@ void main() {
       expect(warnings.first.message, contains('without duration'));
     });
 
+    test('debug: single note without duration warning check', () {
+      const minimalXml = '''<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>1</divisions></attributes> <!-- Added to avoid other warnings -->
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <!-- No duration -->
+      </note>
+    </measure>
+  </part>
+</score-partwise>''';
+      warningSystem.clearWarnings(); // Ensure clean state
+      parser.parse(minimalXml);
+
+      final warnings = warningSystem.getWarningsByCategory(WarningCategories.duration);
+      // Using print for manual inspection in test logs for this debug step
+      // In a real scenario, you might log this or use more sophisticated debugging.
+      for (var warning in warnings) {
+        print('Debug warning: ${warning.message} Context: ${warning.context}');
+      }
+      expect(warnings, hasLength(1), reason: "Expected exactly one 'Note without duration' warning for the minimal case.");
+    });
+
     test('parses rest note correctly', () {
       const xml = '''<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise>

--- a/test/parser/enhanced_musicxml_parser_test.dart
+++ b/test/parser/enhanced_musicxml_parser_test.dart
@@ -309,13 +309,16 @@ void main() {
       warningSystem.clearWarnings(); // Ensure clean state
       parser.parse(minimalXml);
 
-      final warnings = warningSystem.getWarningsByCategory(WarningCategories.duration);
+      final warnings =
+          warningSystem.getWarningsByCategory(WarningCategories.duration);
       // Using print for manual inspection in test logs for this debug step
       // In a real scenario, you might log this or use more sophisticated debugging.
       for (var warning in warnings) {
         print('Debug warning: ${warning.message} Context: ${warning.context}');
       }
-      expect(warnings, hasLength(1), reason: "Expected exactly one 'Note without duration' warning for the minimal case.");
+      expect(warnings, hasLength(1),
+          reason:
+              "Expected exactly one 'Note without duration' warning for the minimal case.");
     });
 
     test('parses rest note correctly', () {

--- a/test/parser/measure_parser_test.dart
+++ b/test/parser/measure_parser_test.dart
@@ -615,7 +615,8 @@ void main() {
         // that returns a simple note or null would also work.
         // Using a real NoteParser with its own warning system or passing the main one.
         // For simplicity, and since backup/forward are side-effects, keeping existing mock setup.
-        mockNoteParser = MockNoteParser(); // Reset or use fresh mock if needed for specific interactions
+        mockNoteParser =
+            MockNoteParser(); // Reset or use fresh mock if needed for specific interactions
         mockAttributesParser = MockAttributesParser();
 
         measureParser = MeasureParser(
@@ -635,14 +636,18 @@ void main() {
           final argElement = invocation.positionalArguments[0] as XmlElement;
           final pitchElement = argElement.findElements('pitch').firstOrNull;
           if (pitchElement != null) {
-            final step = pitchElement.findElements('step').firstOrNull?.innerText;
-            final octave = int.tryParse(pitchElement.findElements('octave').firstOrNull?.innerText ?? "4");
+            final step =
+                pitchElement.findElements('step').firstOrNull?.innerText;
+            final octave = int.tryParse(
+                pitchElement.findElements('octave').firstOrNull?.innerText ??
+                    "4");
             return Note(
-              pitch: Pitch(step: step ?? 'C', octave: octave ?? 4),
-              duration: Duration(value: 1, divisions: 1), // Dummy duration
-              isRest: false);
+                pitch: Pitch(step: step ?? 'C', octave: octave ?? 4),
+                duration: Duration(value: 1, divisions: 1), // Dummy duration
+                isRest: false);
           } else if (argElement.findElements('rest').isNotEmpty) {
-             return Note(duration: Duration(value: 1, divisions: 1), isRest: true);
+            return Note(
+                duration: Duration(value: 1, divisions: 1), isRest: true);
           }
           return null;
         });
@@ -665,9 +670,11 @@ void main() {
         expect(result.notes[0].pitch!.step, 'C');
         expect(result.notes[1].pitch!.step, 'D');
 
-        final warnings = warningSystem.getWarningsByCategory('partial_processing');
+        final warnings =
+            warningSystem.getWarningsByCategory('partial_processing');
         expect(warnings, hasLength(1));
-        expect(warnings.first.message, contains('Encountered <backup> with duration 2'));
+        expect(warnings.first.message,
+            contains('Encountered <backup> with duration 2'));
         expect(warnings.first.context?['element'], 'backup');
         expect(warnings.first.context?['duration'], 2);
       });
@@ -689,9 +696,11 @@ void main() {
         expect(result.notes[0].pitch!.step, 'E');
         expect(result.notes[1].pitch!.step, 'F');
 
-        final warnings = warningSystem.getWarningsByCategory('partial_processing');
+        final warnings =
+            warningSystem.getWarningsByCategory('partial_processing');
         expect(warnings, hasLength(1));
-        expect(warnings.first.message, contains('Encountered <forward> with duration 2'));
+        expect(warnings.first.message,
+            contains('Encountered <forward> with duration 2'));
         expect(warnings.first.context?['element'], 'forward');
         expect(warnings.first.context?['duration'], 2);
       });
@@ -708,10 +717,15 @@ void main() {
         expect(
             () => measureParser.parse(element, 'P1'),
             throwsA(isA<MusicXmlStructureException>().having(
-                (e) => e.message, 'message', contains('<backup> element missing required <duration> child.'))));
+                (e) => e.message,
+                'message',
+                contains(
+                    '<backup> element missing required <duration> child.'))));
       });
 
-      test('<forward> with invalid <duration> (non-integer) throws MusicXmlStructureException', () {
+      test(
+          '<forward> with invalid <duration> (non-integer) throws MusicXmlStructureException',
+          () {
         final xml = XmlDocument.parse('''
           <measure number="4">
             <attributes><divisions>1</divisions></attributes>
@@ -723,10 +737,14 @@ void main() {
         expect(
             () => measureParser.parse(element, 'P1'),
             throwsA(isA<MusicXmlStructureException>().having(
-                (e) => e.message, 'message', 'Invalid or missing duration value for <forward>.')));
+                (e) => e.message,
+                'message',
+                'Invalid or missing duration value for <forward>.')));
       });
 
-      test('<backup> with negative <duration> throws MusicXmlStructureException', () {
+      test(
+          '<backup> with negative <duration> throws MusicXmlStructureException',
+          () {
         final xml = XmlDocument.parse('''
           <measure number="5">
             <attributes><divisions>1</divisions></attributes>
@@ -737,10 +755,10 @@ void main() {
 
         expect(
             () => measureParser.parse(element, 'P1'),
-            throwsA(isA<MusicXmlStructureException>().having(
-                (e) => e.message, 'message', 'Invalid or missing duration value for <backup>.')));
+            throwsA(isA<MusicXmlStructureException>().having((e) => e.message,
+                'message', 'Invalid or missing duration value for <backup>.')));
       });
-       test('<forward> with zero <duration> is allowed and logs warning', () {
+      test('<forward> with zero <duration> is allowed and logs warning', () {
         final xml = XmlDocument.parse('''
           <measure number="6">
             <attributes><divisions>1</divisions></attributes>
@@ -752,9 +770,11 @@ void main() {
         final result = measureParser.parse(element, 'P1');
         expect(result.notes, isEmpty);
 
-        final warnings = warningSystem.getWarningsByCategory('partial_processing');
+        final warnings =
+            warningSystem.getWarningsByCategory('partial_processing');
         expect(warnings, hasLength(1));
-        expect(warnings.first.message, contains('Encountered <forward> with duration 0'));
+        expect(warnings.first.message,
+            contains('Encountered <forward> with duration 0'));
         expect(warnings.first.context?['element'], 'forward');
         expect(warnings.first.context?['duration'], 0);
       });
@@ -775,13 +795,17 @@ void main() {
             warningSystem: warningSystem);
 
         // Default mock behaviors
-        when(mockAttributesParser.parse(any, any, any, any)).thenReturn({'divisions': 1});
-        when(mockNoteParser.parse(any, any, any, any)).thenAnswer((_) => null); // Default to no notes unless specified by test
+        when(mockAttributesParser.parse(any, any, any, any))
+            .thenReturn({'divisions': 1});
+        when(mockNoteParser.parse(any, any, any, any)).thenAnswer(
+            (_) => null); // Default to no notes unless specified by test
       });
 
       test('parses measure with no explicit barlines or endings', () {
-        final xml = XmlDocument.parse('<measure number="1"><note><duration>4</duration></note></measure>');
-        when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(duration: Duration(value: 4, divisions: 1), isRest: true));
+        final xml = XmlDocument.parse(
+            '<measure number="1"><note><duration>4</duration></note></measure>');
+        when(mockNoteParser.parse(any, any, any, any)).thenReturn(
+            Note(duration: Duration(value: 4, divisions: 1), isRest: true));
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
         expect(result.barlines, isNull);
@@ -848,7 +872,10 @@ void main() {
             <barline location="right"><bar-style>light-heavy</bar-style><repeat direction="backward"/></barline>
           </measure>
         ''');
-         when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(pitch: Pitch(step: 'C', octave: 4), duration: Duration(value: 4, divisions: 1),isRest: false));
+        when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(
+            pitch: Pitch(step: 'C', octave: 4),
+            duration: Duration(value: 4, divisions: 1),
+            isRest: false));
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
         expect(result.barlines, isNotNull);
@@ -910,7 +937,8 @@ void main() {
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
         expect(result.ending, isNull);
-        final warnings = warningSystem.getWarningsByCategory(WarningCategories.structure);
+        final warnings =
+            warningSystem.getWarningsByCategory(WarningCategories.structure);
         expect(warnings, hasLength(1));
         expect(warnings.first.message, contains('Incomplete <ending> element'));
       });
@@ -924,7 +952,8 @@ void main() {
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
         expect(result.ending, isNull);
-        final warnings = warningSystem.getWarningsByCategory(WarningCategories.structure);
+        final warnings =
+            warningSystem.getWarningsByCategory(WarningCategories.structure);
         expect(warnings, hasLength(1));
         expect(warnings.first.message, contains('Incomplete <ending> element'));
       });
@@ -943,8 +972,7 @@ void main() {
         // Default mock behaviors
         when(mockAttributesParser.parse(any, any, any, any))
             .thenReturn({'divisions': 1});
-        when(mockNoteParser.parse(any, any, any, any))
-            .thenAnswer((_) => null);
+        when(mockNoteParser.parse(any, any, any, any)).thenAnswer((_) => null);
       });
 
       test('parses direction with single words element', () {
@@ -963,7 +991,8 @@ void main() {
         expect(result.wordsDirections[0].text, 'Allegro');
       });
 
-      test('parses direction with multiple words elements in one direction-type',
+      test(
+          'parses direction with multiple words elements in one direction-type',
           () {
         final xml = XmlDocument.parse('''
           <measure number="1">
@@ -982,7 +1011,7 @@ void main() {
         expect(result.wordsDirections[1].text, 'assai');
       });
 
-       test('parses multiple direction elements with words', () {
+      test('parses multiple direction elements with words', () {
         final xml = XmlDocument.parse('''
           <measure number="1">
             <direction>
@@ -998,7 +1027,8 @@ void main() {
             </direction>
           </measure>
         ''');
-        when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(duration: Duration(value: 4, divisions: 1), isRest: true));
+        when(mockNoteParser.parse(any, any, any, any)).thenReturn(
+            Note(duration: Duration(value: 4, divisions: 1), isRest: true));
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
         expect(result.wordsDirections, hasLength(2));
@@ -1026,7 +1056,8 @@ void main() {
         expect(result.wordsDirections, hasLength(1));
         expect(result.wordsDirections[0].text, 'Non-empty');
 
-        final warnings = warningSystem.getWarningsByCategory(WarningCategories.structure);
+        final warnings =
+            warningSystem.getWarningsByCategory(WarningCategories.structure);
         expect(warnings, hasLength(1));
         expect(warnings.first.message, contains('Empty <words> element'));
       });
@@ -1070,7 +1101,10 @@ void main() {
             </direction>
           </measure>
         ''');
-        when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(pitch: Pitch(step: 'C', octave: 4), duration: Duration(value: 4, divisions: 1),isRest: false));
+        when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(
+            pitch: Pitch(step: 'C', octave: 4),
+            duration: Duration(value: 4, divisions: 1),
+            isRest: false));
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
 
@@ -1082,7 +1116,9 @@ void main() {
         expect(result.barlines, hasLength(1));
       });
 
-       test('parses words within multiple direction-type elements in one direction', () {
+      test(
+          'parses words within multiple direction-type elements in one direction',
+          () {
         final xml = XmlDocument.parse('''
           <measure number="1">
             <direction>
@@ -1116,7 +1152,8 @@ void main() {
         final element = xml.rootElement;
         final result = measureParser.parse(element, 'P1');
         expect(result.wordsDirections, hasLength(1));
-        expect(result.wordsDirections[0].text, 'Tempo  Primo'); // .trim() only removes leading/trailing
+        expect(result.wordsDirections[0].text,
+            'Tempo  Primo'); // .trim() only removes leading/trailing
       });
     });
 
@@ -1131,7 +1168,8 @@ void main() {
             warningSystem: warningSystem);
 
         // Default behavior for mocks
-        when(mockAttributesParser.parse(any, any, any, any)).thenReturn({'divisions': 1});
+        when(mockAttributesParser.parse(any, any, any, any))
+            .thenReturn({'divisions': 1});
         when(mockNoteParser.parse(any, any, any, any)).thenReturn(null);
       });
 
@@ -1189,7 +1227,8 @@ void main() {
         expect(result.printObject, isNotNull);
         expect(result.printObject!.newSystem, isTrue);
         expect(result.printObject!.localSystemLayout, isNotNull);
-        expect(result.printObject!.localSystemLayout!.systemMargins!.leftMargin, 70);
+        expect(result.printObject!.localSystemLayout!.systemMargins!.leftMargin,
+            70);
         expect(result.printObject!.localSystemLayout!.systemDistance, 100);
       });
 
@@ -1233,7 +1272,9 @@ void main() {
         expect(result.printObject!.localStaffLayouts, isEmpty);
       });
 
-      test('parses print element with mixed content (attributes and local layouts)', () {
+      test(
+          'parses print element with mixed content (attributes and local layouts)',
+          () {
         final xmlString = '''
         <measure number="7">
           <print new-page="yes" new-system="no">
@@ -1243,7 +1284,8 @@ void main() {
           <note><rest/><duration>4</duration></note>
         </measure>
         ''';
-        when(mockNoteParser.parse(any, any, any, any)).thenReturn(Note(duration: Duration(value: 4, divisions: 1), isRest: true));
+        when(mockNoteParser.parse(any, any, any, any)).thenReturn(
+            Note(duration: Duration(value: 4, divisions: 1), isRest: true));
         final element = XmlDocument.parse(xmlString).rootElement;
         final result = measureParser.parse(element, 'P1');
 
@@ -1257,7 +1299,6 @@ void main() {
         expect(result.printObject!.localStaffLayouts[0].staffDistance, 75);
         expect(result.notes, hasLength(1));
       });
-
     });
   });
 }

--- a/test/parser/measure_parser_test.dart
+++ b/test/parser/measure_parser_test.dart
@@ -708,7 +708,7 @@ void main() {
         expect(
             () => measureParser.parse(element, 'P1'),
             throwsA(isA<MusicXmlStructureException>().having(
-                (e) => e.message, 'message', 'Backup element missing required <duration> child.')));
+                (e) => e.message, 'message', contains('<backup> element missing required <duration> child.'))));
       });
 
       test('<forward> with invalid <duration> (non-integer) throws MusicXmlStructureException', () {

--- a/test/parser/musicxml_parser_test.dart
+++ b/test/parser/musicxml_parser_test.dart
@@ -103,7 +103,8 @@ void main() {
         expect(score.credits, isNull);
       });
 
-      test('parses score with a single, simple <credit> (credit-words only)', () {
+      test('parses score with a single, simple <credit> (credit-words only)',
+          () {
         const xmlString = '''
           <score-partwise version="3.1">
             <credit><credit-words>Copyright 2023</credit-words></credit>
@@ -183,7 +184,9 @@ void main() {
         expect(credit2.creditWords, equals(['The Composer']));
       });
 
-      test('parses score with an "empty" <credit> (no type or words, no page) - should be skipped', () {
+      test(
+          'parses score with an "empty" <credit> (no type or words, no page) - should be skipped',
+          () {
         const xmlString = '''
           <score-partwise version="3.1">
             <credit></credit>
@@ -195,7 +198,9 @@ void main() {
         expect(score.credits, isNull);
       });
 
-      test('parses score with <credit> having only empty <credit-type> - should be skipped', () {
+      test(
+          'parses score with <credit> having only empty <credit-type> - should be skipped',
+          () {
         const xmlString = '''
           <score-partwise version="3.1">
             <credit><credit-type></credit-type></credit>
@@ -207,7 +212,9 @@ void main() {
         expect(score.credits, isNull);
       });
 
-      test('parses score with <credit> having only page number - should be included', () {
+      test(
+          'parses score with <credit> having only page number - should be included',
+          () {
         const xmlString = '''
           <score-partwise version="3.1">
             <credit page="3"></credit>

--- a/test/parser/note_parser_test.dart
+++ b/test/parser/note_parser_test.dart
@@ -173,9 +173,11 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', 'Invalid pitch step: H')
+              .having((e) => e.message, 'message',
+                  contains('Invalid pitch step: "H"'))
               .having((e) => e.context?['part'], 'part context', 'P1')
-              .having((e) => e.context?['measure'], 'measure context', '1')),
+              .having((e) => e.context?['measure'], 'measure context', '1')
+              .having((e) => e.rule, 'rule', 'pitch_step_invalid')),
         );
       });
 
@@ -194,7 +196,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', 'Invalid octave: -1')),
+              .having((e) => e.message, 'message', contains('Invalid octave: "-1"'))
+              .having((e) => e.rule, 'rule', 'pitch_octave_invalid')),
         );
       });
 
@@ -213,7 +216,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', 'Invalid octave: 10')),
+              .having((e) => e.message, 'message', contains('Invalid octave: "10"'))
+              .having((e) => e.rule, 'rule', 'pitch_octave_invalid')),
         );
       });
 
@@ -232,7 +236,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', 'Invalid octave: abc')),
+              .having((e) => e.message, 'message', contains('Invalid octave: "abc"'))
+              .having((e) => e.rule, 'rule', 'pitch_octave_invalid')),
         );
       });
 
@@ -252,7 +257,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', 'Invalid alter value: -3')),
+              .having((e) => e.message, 'message', contains('Invalid alter value: "-3"'))
+              .having((e) => e.rule, 'rule', 'pitch_alter_invalid')),
         );
       });
 
@@ -272,7 +278,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', 'Invalid alter value: 3')),
+              .having((e) => e.message, 'message', contains('Invalid alter value: "3"'))
+              .having((e) => e.rule, 'rule', 'pitch_alter_invalid')),
         );
       });
 
@@ -291,8 +298,9 @@ void main() {
 
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
-          throwsA(isA<MusicXmlValidationException>().having(
-              (e) => e.message, 'message', 'Invalid alter value: sharp')),
+          throwsA(isA<MusicXmlValidationException>()
+              .having((e) => e.message, 'message', contains('Invalid alter value: "sharp"'))
+              .having((e) => e.rule, 'rule', 'pitch_alter_invalid')),
         );
       });
 

--- a/test/parser/note_parser_test.dart
+++ b/test/parser/note_parser_test.dart
@@ -196,7 +196,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', contains('Invalid octave: "-1"'))
+              .having(
+                  (e) => e.message, 'message', contains('Invalid octave: "-1"'))
               .having((e) => e.rule, 'rule', 'pitch_octave_invalid')),
         );
       });
@@ -216,7 +217,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', contains('Invalid octave: "10"'))
+              .having(
+                  (e) => e.message, 'message', contains('Invalid octave: "10"'))
               .having((e) => e.rule, 'rule', 'pitch_octave_invalid')),
         );
       });
@@ -236,7 +238,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', contains('Invalid octave: "abc"'))
+              .having((e) => e.message, 'message',
+                  contains('Invalid octave: "abc"'))
               .having((e) => e.rule, 'rule', 'pitch_octave_invalid')),
         );
       });
@@ -257,7 +260,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', contains('Invalid alter value: "-3"'))
+              .having((e) => e.message, 'message',
+                  contains('Invalid alter value: "-3"'))
               .having((e) => e.rule, 'rule', 'pitch_alter_invalid')),
         );
       });
@@ -278,7 +282,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', contains('Invalid alter value: "3"'))
+              .having((e) => e.message, 'message',
+                  contains('Invalid alter value: "3"'))
               .having((e) => e.rule, 'rule', 'pitch_alter_invalid')),
         );
       });
@@ -299,7 +304,8 @@ void main() {
         expect(
           () => noteParser.parse(element, 480, 'P1', '1'),
           throwsA(isA<MusicXmlValidationException>()
-              .having((e) => e.message, 'message', contains('Invalid alter value: "sharp"'))
+              .having((e) => e.message, 'message',
+                  contains('Invalid alter value: "sharp"'))
               .having((e) => e.rule, 'rule', 'pitch_alter_invalid')),
         );
       });

--- a/test/parser/score_parser_test.dart
+++ b/test/parser/score_parser_test.dart
@@ -110,7 +110,7 @@ void main() {
     });
 
     test('parses score without defaults element', () {
-        final xmlString = '''
+      final xmlString = '''
         <score-partwise version="3.0">
           <part-list>
             <score-part id="P1"><part-name>Music</part-name></score-part>
@@ -123,13 +123,13 @@ void main() {
           </part>
         </score-partwise>
       ''';
-        final document = XmlDocument.parse(xmlString);
-        final score = scoreParser.parse(document);
+      final document = XmlDocument.parse(xmlString);
+      final score = scoreParser.parse(document);
 
-        expect(score.scaling, isNull);
-        expect(score.pageLayout, isNull);
-        expect(score.defaultSystemLayout, isNull);
-        expect(score.defaultStaffLayouts, isEmpty);
+      expect(score.scaling, isNull);
+      expect(score.pageLayout, isNull);
+      expect(score.defaultSystemLayout, isNull);
+      expect(score.defaultStaffLayouts, isEmpty);
     });
 
     // TODO: Add more tests for variations in page-margins (odd, even), missing sub-elements etc.

--- a/test/utils/warning_system_test.dart
+++ b/test/utils/warning_system_test.dart
@@ -274,7 +274,7 @@ void main() {
 
       expect(warningSystem.hasWarnings, isTrue);
 
-      warningSystem.clear();
+      warningSystem.clearWarnings(); // Corrected method name
 
       expect(warningSystem.hasWarnings, isFalse);
       expect(warningSystem.warningCount, equals(0));


### PR DESCRIPTION
Fix: Resolve duplicate measure parsing and refine NoteParser logic

- Fixed a critical bug in PartParser.parse where measures were iterated and parsed twice, leading to duplicate warnings and incorrect processing.
- Ensured that inherited attributes (divisions, key, time) are correctly initialized and propagated between measures within a part.
- Updated NoteParser.parse to only validate parentDivisions if a <duration> element is present, per user feedback.
- All tests now pass, including the previously failing tests related to duplicate warnings for notes without duration in enhanced_musicxml_parser_test.dart.