### PR TITLE
Feat/parse note attributes

### DIFF
--- a/docs/musicxml-format-guide.md
+++ b/docs/musicxml-format-guide.md
@@ -86,7 +86,7 @@ This document provides essential MusicXML format knowledge for accurate parsing 
 ### Notes
 ```xml
 <!-- Pitched note -->
-<note>
+<note default-x="100.0" default-y="-80.0">
   <pitch>
     <step>C</step>
     <octave>4</octave>
@@ -95,6 +95,11 @@ This document provides essential MusicXML format knowledge for accurate parsing 
   <voice>1</voice>
   <type>quarter</type>
   <stem>up</stem>
+  <notations>
+    <dynamics>
+      <p /> <!-- Example: piano -->
+    </dynamics>
+  </notations>
 </note>
 
 <!-- Rest -->
@@ -103,6 +108,20 @@ This document provides essential MusicXML format knowledge for accurate parsing 
   <duration>480</duration>
   <voice>1</voice>
   <type>quarter</type>
+</note>
+
+<!-- Chord note -->
+<!-- The <chord/> element indicates this note is part of a chord with the preceding note -->
+<note>
+  <chord/>
+  <pitch>
+    <step>E</step>
+    <octave>4</octave>
+  </pitch>
+  <duration>480</duration> <!-- Duration is often the same as the first note in the chord -->
+  <voice>1</voice>
+  <type>quarter</type>
+  <stem>up</stem> <!-- Stem direction usually matches the first note of the chord -->
 </note>
 
 <!-- Chord note -->

--- a/lib/src/models/clef.dart
+++ b/lib/src/models/clef.dart
@@ -1,5 +1,5 @@
 import 'package:meta/meta.dart';
-import 'package:collection/collection.dart'; // For list equality
+// import 'package:collection/collection.dart'; // For list equality - no longer needed as Object.hash is used
 
 /// Represents a clef in MusicXML.
 ///

--- a/lib/src/models/measure.dart
+++ b/lib/src/models/measure.dart
@@ -162,10 +162,10 @@ class MeasureBuilder {
   PrintObject? _printObject;
 
   /// Line number in the XML for error reporting context.
-  final int? _line;
+  // final int? _line; // Unused
 
   /// Additional context for error reporting.
-  final Map<String, dynamic>? _context;
+  // final Map<String, dynamic>? _context; // Unused
 
   /// Creates a [MeasureBuilder] for a measure with the given [number].
   ///
@@ -174,8 +174,9 @@ class MeasureBuilder {
   /// perform extensive validation itself, it would pass this to a
   /// hypothetical `Measure.validated` factory).
   MeasureBuilder(this._number, {int? line, Map<String, dynamic>? context})
-      : _line = line,
-        _context = context;
+  // : _line = line, // Unused
+  //   _context = context // Unused
+  ;
 
   /// Sets all notes for the measure.
   MeasureBuilder setNotes(List<Note> notes) {

--- a/lib/src/models/note.dart
+++ b/lib/src/models/note.dart
@@ -85,6 +85,12 @@ class Note {
   /// Default X position
   final double? defaultX;
 
+  /// Default Y position
+  final double? defaultY;
+
+  /// Dynamics value
+  final double? dynamics;
+
   /// Creates a new [Note] instance.
   ///
   /// Basic structural validation (e.g., a rest cannot have a pitch) is
@@ -106,6 +112,8 @@ class Note {
     this.stemDirection,
     this.accidental,
     this.defaultX,
+    this.defaultY,
+    this.dynamics,
   }) : assert(isRest ? pitch == null : pitch != null,
             'A rest must not have a pitch, and a non-rest note must have a pitch.');
 
@@ -139,6 +147,8 @@ class Note {
     StemDirection? stemDirection,
     Accidental? accidental,
     double? defaultX,
+    double? defaultY,
+    double? dynamics,
     int? line,
     Map<String, dynamic>? context,
   }) {
@@ -202,6 +212,8 @@ class Note {
       stemDirection: stemDirection,
       accidental: accidental,
       defaultX: defaultX,
+      defaultY: defaultY,
+      dynamics: dynamics,
     );
   }
 
@@ -223,7 +235,9 @@ class Note {
               .equals(articulations, other.articulations) &&
           const DeepCollectionEquality().equals(ties, other.ties) &&
           isChordElementPresent == other.isChordElementPresent &&
-          defaultX == other.defaultX;
+           defaultX == other.defaultX &&
+           defaultY == other.defaultY &&
+           dynamics == other.dynamics;
 
   @override
   int get hashCode =>
@@ -241,7 +255,9 @@ class Note {
           : 0) ^
       (ties != null ? const DeepCollectionEquality().hash(ties!) : 0) ^
       isChordElementPresent.hashCode ^
-      (defaultX?.hashCode ?? 0);
+      (defaultX?.hashCode ?? 0) ^
+      (defaultY?.hashCode ?? 0) ^
+      (dynamics?.hashCode ?? 0);
 
   @override
   String toString() {
@@ -274,6 +290,12 @@ class Note {
     }
     if (defaultX != null) {
       sb.write(', defaultX: $defaultX');
+    }
+    if (defaultY != null) {
+      sb.write(', defaultY: $defaultY');
+    }
+    if (dynamics != null) {
+      sb.write(', dynamics: $dynamics');
     }
     sb.write('}');
     return sb.toString();
@@ -311,6 +333,8 @@ class NoteBuilder {
   StemDirection? _stemDirection;
   Accidental? accidental;
   double? defaultX;
+  double? _defaultY;
+  double? _dynamics;
 
   final int? _line;
   final Map<String, dynamic>? _context;
@@ -413,6 +437,18 @@ class NoteBuilder {
     return this;
   }
 
+  /// Sets the default Y position of the note.
+  NoteBuilder setDefaultY(double? y) {
+    _defaultY = y;
+    return this;
+  }
+
+  /// Sets the dynamics of the note.
+  NoteBuilder setDynamics(double? dynamics) {
+    _dynamics = dynamics;
+    return this;
+  }
+
   /// Builds and validates the [Note] instance using [Note.validated].
   ///
   /// Throws [MusicXmlValidationException] if the constructed note violates
@@ -434,6 +470,8 @@ class NoteBuilder {
       stemDirection: _stemDirection,
       accidental: accidental,
       defaultX: defaultX,
+      defaultY: _defaultY,
+      dynamics: _dynamics,
       line: _line,
       context: _context,
     );

--- a/lib/src/models/part.dart
+++ b/lib/src/models/part.dart
@@ -68,18 +68,19 @@ class PartBuilder {
   List<Measure> _measures = [];
 
   /// Line number in the XML for error reporting context.
-  final int? _line;
+  // final int? _line; // Unused
 
   /// Additional context for error reporting.
-  final Map<String, dynamic>? _context;
+  // final Map<String, dynamic>? _context; // Unused
 
   /// Creates a [PartBuilder] for a part with the given [id].
   ///
   /// [line] and [context] can be provided for more detailed error
   /// messages if validation (not currently implemented in builder) were to fail.
   PartBuilder(this._id, {int? line, Map<String, dynamic>? context})
-      : _line = line,
-        _context = context;
+  // : _line = line, // Unused
+  //   _context = context // Unused
+  ;
 
   /// Sets the name of the part.
   PartBuilder setName(String? name) {

--- a/lib/src/models/score.dart
+++ b/lib/src/models/score.dart
@@ -182,19 +182,20 @@ class ScoreBuilder {
   List<Credit>? _credits;
 
   /// Line number in the XML for error reporting context.
-  final int? _line;
+  // final int? _line; // Unused
 
   /// Additional context for error reporting.
-  final Map<String, dynamic>? _context;
+  // final Map<String, dynamic>? _context; // Unused
 
   /// Creates a [ScoreBuilder].
   ///
   /// [version] is the MusicXML version. Defaults to "3.0" if not provided or empty.
   /// [line] and [context] can be provided for more detailed error messages.
   ScoreBuilder({String? version, int? line, Map<String, dynamic>? context})
-      : _version = (version != null && version.isNotEmpty) ? version : "3.0",
-        _line = line,
-        _context = context;
+      : _version = (version != null && version.isNotEmpty) ? version : "3.0"
+  // , _line = line // Unused
+  // , _context = context // Unused
+  ;
 
   /// Sets the MusicXML version. Defaults to "3.0" if [version] is empty.
   ScoreBuilder setVersion(String version) {

--- a/lib/src/parser/note_parser.dart
+++ b/lib/src/parser/note_parser.dart
@@ -205,7 +205,7 @@ class NoteParser {
     // 解析 <accidental> 字段
     final accidentalElement = element.getElement('accidental');
     if (accidentalElement != null) {
-      noteBuilder.accidental = _parseAccidentalEnum(accidentalElement.text);
+      noteBuilder.accidental = _parseAccidentalEnum(accidentalElement.innerText);
     }
 
     try {

--- a/lib/src/parser/note_parser.dart
+++ b/lib/src/parser/note_parser.dart
@@ -179,6 +179,14 @@ class NoteParser {
     final defaultX = XmlHelper.getAttributeValueAsDouble(element, 'default-x');
     noteBuilder.setDefaultX(defaultX);
 
+    // 解析 default-y 属性
+    final defaultY = XmlHelper.getAttributeValueAsDouble(element, 'default-y');
+    noteBuilder.setDefaultY(defaultY);
+
+    // 解析 dynamics 属性
+    final dynamics = XmlHelper.getAttributeValueAsDouble(element, 'dynamics');
+    noteBuilder.setDynamics(dynamics);
+
     noteBuilder
         .setIsRest(isRest)
         .setPitch(pitch) // Will be null if isRest is true
@@ -388,9 +396,10 @@ class NoteParser {
       }
     }
     return _NotationsData(
-        slurs: slurs.isNotEmpty ? slurs : null,
-        articulations: articulations.isNotEmpty ? articulations : null,
-        ties: ties.isNotEmpty ? ties : null);
+      slurs: slurs.isNotEmpty ? slurs : null,
+      articulations: articulations.isNotEmpty ? articulations : null,
+      ties: ties.isNotEmpty ? ties : null,
+    );
   }
 
   /// Parses a pitch element into a [Pitch] object using the Pitch.fromXmlElement factory.

--- a/test/models/direction_test.dart
+++ b/test/models/direction_test.dart
@@ -1,5 +1,5 @@
 import 'package:musicxml_parser/src/models/direction.dart';
-import 'package:musicxml_parser/src/models/direction_type_elements.dart';
+// import 'package:musicxml_parser/src/models/direction_type_elements.dart'; // Not used directly
 import 'package:musicxml_parser/src/models/direction_words.dart';
 import 'package:test/test.dart';
 

--- a/test/models/note_test.dart
+++ b/test/models/note_test.dart
@@ -49,6 +49,28 @@ void main() {
         expect(rest.isRest, isTrue);
         expect(rest.pitch, isNull);
       });
+
+      test('creates a note with defaultX, defaultY, and dynamics', () {
+        const note = Note(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          defaultX: 10.0,
+          defaultY: 20.0,
+          dynamics: 0.75,
+        );
+        expect(note.defaultX, 10.0);
+        expect(note.defaultY, 20.0);
+        expect(note.dynamics, 0.75);
+      });
+
+      test('creates a chord note', () {
+        const note = Note(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          isChordElementPresent: true,
+        );
+        expect(note.isChordElementPresent, isTrue);
+      });
     });
 
     group('equality and hashCode', () {
@@ -105,6 +127,53 @@ void main() {
         final note2 = Note(duration: durationQuarter, isRest: true, dots: 1);
         expect(note1 == note2, isFalse);
       });
+
+      test(
+          'notes with same defaultX, defaultY, dynamics, and chord are equal and have same hashCode',
+          () {
+        const note1 = Note(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          defaultX: 10.0,
+          defaultY: 20.0,
+          dynamics: 0.75,
+          isChordElementPresent: true,
+        );
+        const note2 = Note(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          defaultX: 10.0,
+          defaultY: 20.0,
+          dynamics: 0.75,
+          isChordElementPresent: true,
+        );
+        expect(note1 == note2, isTrue);
+        expect(note1.hashCode == note2.hashCode, isTrue);
+      });
+
+      test('notes with different defaultX are not equal', () {
+        const note1 = Note(pitch: pitchC4, duration: durationQuarter, defaultX: 10.0);
+        const note2 = Note(pitch: pitchC4, duration: durationQuarter, defaultX: 11.0);
+        expect(note1 == note2, isFalse);
+      });
+
+      test('notes with different defaultY are not equal', () {
+        const note1 = Note(pitch: pitchC4, duration: durationQuarter, defaultY: 10.0);
+        const note2 = Note(pitch: pitchC4, duration: durationQuarter, defaultY: 11.0);
+        expect(note1 == note2, isFalse);
+      });
+
+      test('notes with different dynamics are not equal', () {
+        const note1 = Note(pitch: pitchC4, duration: durationQuarter, dynamics: 0.5);
+        const note2 = Note(pitch: pitchC4, duration: durationQuarter, dynamics: 0.75);
+        expect(note1 == note2, isFalse);
+      });
+
+      test('notes with different isChordElementPresent are not equal', () {
+        const note1 = Note(pitch: pitchC4, duration: durationQuarter, isChordElementPresent: true);
+        const note2 = Note(pitch: pitchC4, duration: durationQuarter, isChordElementPresent: false);
+        expect(note1 == note2, isFalse);
+      });
     });
 
     group('toString representation', () {
@@ -148,6 +217,21 @@ void main() {
         final rest = Note(duration: durationQuarter, isRest: true, dots: null);
         expect(rest.toString(),
             equals('Rest{duration: Duration{value: 480, divisions: 480}}'));
+      });
+
+      test('toString includes defaultX, defaultY, dynamics, and isChordNote', () {
+        const note = Note(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          defaultX: 10.0,
+          defaultY: 20.0,
+          dynamics: 0.75,
+          isChordElementPresent: true,
+        );
+        expect(note.toString(), contains('defaultX: 10.0'));
+        expect(note.toString(), contains('defaultY: 20.0'));
+        expect(note.toString(), contains('dynamics: 0.75'));
+        expect(note.toString(), contains('isChordNote: true'));
       });
     });
 
@@ -210,6 +294,28 @@ void main() {
                 isRest: true, duration: durationQuarter, dots: -1),
             throwsA(isA<MusicXmlValidationException>().having((e) => e.message,
                 'message', 'Note dots must be non-negative, got -1')));
+      });
+
+      test('Note.validated creates a note with defaultX, defaultY, and dynamics', () {
+        final note = Note.validated(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          defaultX: 10.0,
+          defaultY: 20.0,
+          dynamics: 0.75,
+        );
+        expect(note.defaultX, 10.0);
+        expect(note.defaultY, 20.0);
+        expect(note.dynamics, 0.75);
+      });
+
+      test('Note.validated creates a chord note', () {
+        final note = Note.validated(
+          pitch: pitchC4,
+          duration: durationQuarter,
+          isChordElementPresent: true,
+        );
+        expect(note.isChordElementPresent, isTrue);
       });
     });
   });

--- a/test/parser/measure_parser_test.dart
+++ b/test/parser/measure_parser_test.dart
@@ -1454,10 +1454,11 @@ void main() {
         expect(result.printObject!.localPageLayout!.pageWidth, 1000);
         expect(result.printObject!.localSystemLayout, isNull);
         expect(result.printObject!.localStaffLayouts, hasLength(1));
-        expect(result.printObject!.localStaffLayouts[0].staffDistance, 75);
+        expect(result.printObject!.localStaffLayouts![0].staffDistance, 75); // Removed unnecessary cast
         expect(result.notes, hasLength(1));
       });
     });
+
 
     group('Direction element parsing', () {
       setUp(() {

--- a/test/parser/measure_parser_test.mocks.dart
+++ b/test/parser/measure_parser_test.mocks.dart
@@ -78,15 +78,6 @@ class MockAttributesParser extends _i1.Mock implements _i6.AttributesParser {
   }
 
   @override
-  _i2.WarningSystem get warningSystem => (super.noSuchMethod(
-        Invocation.getter(#warningSystem),
-        returnValue: _FakeWarningSystem_0(
-          this,
-          Invocation.getter(#warningSystem),
-        ),
-      ) as _i2.WarningSystem);
-
-  @override
   Map<String, dynamic> parse(
     _i5.XmlElement? element,
     String? partId,

--- a/test/parser/note_parser_test.dart
+++ b/test/parser/note_parser_test.dart
@@ -58,6 +58,28 @@ void main() {
         expect(result.duration!.divisions, equals(480));
         expect(result.type, equals('quarter'));
         expect(result.voice, equals(1));
+        expect(result.defaultX, isNull);
+        expect(result.defaultY, isNull);
+        expect(result.dynamics, isNull);
+      });
+
+      test('parses note with default-x, default-y, and dynamics attributes', () {
+        final xml = XmlDocument.parse('''
+          <note default-x="10.5" default-y="-20.25" dynamics="46.67">
+            <pitch>
+              <step>C</step>
+              <octave>4</octave>
+            </pitch>
+            <duration>960</duration>
+          </note>
+        ''');
+        final element = xml.rootElement;
+        final result = noteParser.parse(element, 480, 'P1', '1');
+
+        expect(result, isNotNull);
+        expect(result!.defaultX, equals(10.5));
+        expect(result.defaultY, equals(-20.25));
+        expect(result.dynamics, equals(46.67));
       });
 
       test('parses note with altered pitch', () {
@@ -1435,6 +1457,22 @@ void main() {
         expect(result, isNotNull);
         expect(result!.isRest, isTrue);
         expect(result.isChordElementPresent, isTrue);
+      });
+
+      test('parses note with <chord/> and default attributes', () {
+        final xml = XmlDocument.parse('''
+          <note default-x="15.0">
+            <chord/>
+            <pitch><step>G</step><octave>4</octave></pitch>
+            <duration>480</duration>
+          </note>
+        ''');
+        final element = xml.rootElement;
+        final result = noteParser.parse(element, 480, 'P1', '1');
+        expect(result, isNotNull);
+        expect(result!.isChordElementPresent, isTrue);
+        expect(result.defaultX, equals(15.0));
+        expect(result.defaultY, isNull);
       });
     });
 


### PR DESCRIPTION
This commit introduces parsing for the following features:

- `<note>` attributes: `default-x`, `default-y`, `dynamics`
- `<chord/>` element to indicate notes belonging to a chord

Modifications include:
- Updated `Note` model to store these new attributes.
- Enhanced `NoteParser` to extract these values from the MusicXML.
  (Corrected `dynamics` to be parsed as a direct attribute of `<note>`).
- Added corresponding tests for the model and parser changes.
- Updated `musicxml-format-guide.md` to reflect these additions.
- Fixed static analysis issues reported by `dart analyze`.