### PR TITLE
Port Dart models to C#

### DIFF
--- a/csharp/MusicXMLParser/Exceptions/InvalidMusicXmlException.cs
+++ b/csharp/MusicXMLParser/Exceptions/InvalidMusicXmlException.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Text;
+
+namespace MusicXMLParser.Exceptions
+{
+    /// <summary>
+    /// Base exception for errors encountered during MusicXML parsing or validation.
+    /// </summary>
+    public class InvalidMusicXmlException : Exception
+    {
+        /// <summary>
+        /// The XML node content or identifier where the error occurred, if available.
+        /// </summary>
+        public string Node { get; }
+
+        /// <summary>
+        /// The line number in the XML file where the error occurred, if available.
+        /// </summary>
+        public string Line { get; } // Changed to string to match other usages
+
+        /// <summary>
+        /// Creates a new <see cref="InvalidMusicXmlException"/> with the given message.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="line">The line number where the error occurred (optional).</param>
+        /// <param name="node">The XML node where the error occurred (optional).</param>
+        public InvalidMusicXmlException(string message, string line = null, string node = null)
+            : base(message)
+        {
+            Node = node;
+            Line = line;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="InvalidMusicXmlException"/> with the given message and inner exception.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="line">The line number where the error occurred (optional).</param>
+        /// <param name="node">The XML node where the error occurred (optional).</param>
+        public InvalidMusicXmlException(string message, Exception innerException, string line = null, string node = null)
+            : base(message, innerException)
+        {
+            Node = node;
+            Line = line;
+        }
+
+        public override string ToString()
+        {
+            var buffer = new StringBuilder($"{GetType().Name}: {Message}"); // Use GetType().Name for specific exception type
+            if (!string.IsNullOrEmpty(Node))
+            {
+                buffer.Append($" (node: {Node}");
+                if (!string.IsNullOrEmpty(Line))
+                {
+                    buffer.Append($", line: {Line}");
+                }
+                buffer.Append(")");
+            }
+            else if (!string.IsNullOrEmpty(Line))
+            {
+                buffer.Append($" (line: {Line})");
+            }
+            return buffer.ToString();
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Exceptions/MusicXmlStructureException.cs
+++ b/csharp/MusicXMLParser/Exceptions/MusicXmlStructureException.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MusicXMLParser.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when MusicXML content has structural problems.
+    /// </summary>
+    /// <remarks>
+    /// This exception is used for errors related to the overall structure of the
+    /// MusicXML document, such as missing required elements, invalid element hierarchy,
+    /// or incorrect document format.
+    /// </remarks>
+    public class MusicXmlStructureException : InvalidMusicXmlException
+    {
+        /// <summary>
+        /// The required element that is missing or invalid.
+        /// </summary>
+        public string RequiredElement { get; }
+
+        /// <summary>
+        /// The parent element where the structure problem occurred.
+        /// </summary>
+        public string ParentElement { get; }
+
+        /// <summary>
+        /// Additional context information about the structural problem.
+        /// </summary>
+        public Dictionary<string, string> Context { get; }
+
+        /// <summary>
+        /// An optional rule identifier associated with this structural error.
+        /// </summary>
+        public string Rule { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="MusicXmlStructureException"/> with the given message.
+        /// </summary>
+        /// <param name="message">A descriptive error message.</param>
+        /// <param name="requiredElement">The required element that is missing or invalid (optional).</param>
+        /// <param name="parentElement">The parent element where the problem occurred (optional).</param>
+        /// <param name="line">The line number where the error occurred (optional).</param>
+        /// <param name="node">The XML node where the error occurred (optional).</param>
+        /// <param name="context">Additional context information (optional).</param>
+        /// <param name="rule">An optional rule identifier (optional).</param>
+        public MusicXmlStructureException(
+            string message,
+            string requiredElement = null,
+            string parentElement = null,
+            string line = null, // Changed to string to match Pitch.cs
+            string node = null,
+            Dictionary<string, string> context = null,
+            string rule = null)
+            : base(message, line, node)
+        {
+            RequiredElement = requiredElement;
+            ParentElement = parentElement;
+            Context = context;
+            Rule = rule;
+        }
+
+        public override string ToString()
+        {
+            var buffer = new StringBuilder($"MusicXmlStructureException: {Message}");
+
+            if (!string.IsNullOrEmpty(RequiredElement))
+            {
+                buffer.Append($" [required: {RequiredElement}");
+                if (!string.IsNullOrEmpty(ParentElement))
+                {
+                    buffer.Append($" in {ParentElement}");
+                }
+                buffer.Append("]");
+            }
+
+            if (!string.IsNullOrEmpty(Node)) // Assuming Node and Line are properties in Base
+            {
+                buffer.Append($" (node: {Node}");
+                if (!string.IsNullOrEmpty(Line)) // Assuming Line is a string property in Base
+                {
+                    buffer.Append($", line: {Line}");
+                }
+                buffer.Append(")");
+            }
+            else if (!string.IsNullOrEmpty(Line))
+            {
+                buffer.Append($" (line: {Line})");
+            }
+
+            if (Context != null && Context.Count > 0)
+            {
+                buffer.Append($" [context: {string.Join(", ", Context.Select(kv => $"{kv.Key}={kv.Value}"))}]");
+            }
+
+            if (!string.IsNullOrEmpty(Rule))
+            {
+                buffer.Append($" [rule: {Rule}]");
+            }
+
+            return buffer.ToString();
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Exceptions/MusicXmlValidationException.cs
+++ b/csharp/MusicXMLParser/Exceptions/MusicXmlValidationException.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MusicXMLParser.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when MusicXML content violates musical rules or constraints.
+    /// </summary>
+    /// <remarks>
+    /// This exception is used for errors related to musical validation, such as
+    /// invalid pitch ranges, incorrect measure durations, or inconsistent voice assignments.
+    /// </remarks>
+    public class MusicXmlValidationException : InvalidMusicXmlException
+    {
+        /// <summary>
+        /// The specific validation rule that was violated.
+        /// </summary>
+        public string Rule { get; }
+
+        /// <summary>
+        /// Additional context information about the validation failure.
+        /// </summary>
+        public Dictionary<string, string> Context { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="MusicXmlValidationException"/> with the given message.
+        /// </summary>
+        /// <param name="message">A descriptive error message.</param>
+        /// <param name="rule">The validation rule that was violated (optional).</param>
+        /// <param name="line">The line number where the error occurred (optional).</param>
+        /// <param name="node">The XML node where the error occurred (optional).</param>
+        /// <param name="context">Additional context information (optional).</param>
+        public MusicXmlValidationException(
+            string message,
+            string rule = null,
+            string line = null, // Changed to string
+            string node = null,
+            Dictionary<string, string> context = null)
+            : base(message, line, node)
+        {
+            Rule = rule;
+            Context = context;
+        }
+
+        public override string ToString()
+        {
+            var buffer = new StringBuilder($"MusicXmlValidationException: {Message}");
+
+            if (!string.IsNullOrEmpty(Rule))
+            {
+                buffer.Append($" [rule: {Rule}]");
+            }
+
+            if (!string.IsNullOrEmpty(Node))
+            {
+                buffer.Append($" (node: {Node}");
+                if (!string.IsNullOrEmpty(Line)) // Line is string
+                {
+                    buffer.Append($", line: {Line}");
+                }
+                buffer.Append(")");
+            }
+            else if (!string.IsNullOrEmpty(Line))
+            {
+                buffer.Append($" (line: {Line})");
+            }
+
+            if (Context != null && Context.Any())
+            {
+                buffer.Append($" [context: {string.Join(", ", Context.Select(kv => $"{kv.Key}={kv.Value}"))}]");
+            }
+
+            return buffer.ToString();
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/MeasureLayoutInfo.cs
+++ b/csharp/MusicXMLParser/Models/MeasureLayoutInfo.cs
@@ -2,19 +2,19 @@ using System;
 
 namespace MusicXMLParser.Models
 {
-    public class MeasureLayout : IEquatable<MeasureLayout>
+    public class MeasureLayoutInfo : IEquatable<MeasureLayoutInfo>
     {
         public double? MeasureDistance { get; }
 
-        public MeasureLayout(double? measureDistance = null)
+        public MeasureLayoutInfo(double? measureDistance = null)
         {
             MeasureDistance = measureDistance;
         }
 
-        public override bool Equals(object obj) => Equals(obj as MeasureLayout);
-        public bool Equals(MeasureLayout other) => other != null && MeasureDistance == other.MeasureDistance;
+        public override bool Equals(object obj) => Equals(obj as MeasureLayoutInfo);
+        public bool Equals(MeasureLayoutInfo other) => other != null && MeasureDistance == other.MeasureDistance;
         public override int GetHashCode() => MeasureDistance.GetHashCode();
-        public override string ToString() => $"MeasureLayout{{measureDistance: {MeasureDistance}}}";
+        public override string ToString() => $"MeasureLayoutInfo{{measureDistance: {MeasureDistance}}}";
     }
 
     public enum MeasureNumberingValue { None, Measure, System }

--- a/csharp/MusicXMLParser/Models/PageLayout.cs
+++ b/csharp/MusicXMLParser/Models/PageLayout.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MusicXMLParser.Models
+{
+    public class PageMargins
+    {
+        public string Type { get; set; } // "odd", "even", "both"
+        public double? LeftMargin { get; set; }
+        public double? RightMargin { get; set; }
+        public double? TopMargin { get; set; }
+        public double? BottomMargin { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PageMargins other)
+            {
+                return Type == other.Type &&
+                       LeftMargin == other.LeftMargin &&
+                       RightMargin == other.RightMargin &&
+                       TopMargin == other.TopMargin &&
+                       BottomMargin == other.BottomMargin;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, LeftMargin, RightMargin, TopMargin, BottomMargin);
+        }
+
+        public override string ToString()
+        {
+            return $"PageMargins{{Type: {Type}, LeftMargin: {LeftMargin}, RightMargin: {RightMargin}, TopMargin: {TopMargin}, BottomMargin: {BottomMargin}}}";
+        }
+    }
+
+    public class PageLayout
+    {
+        public double? PageHeight { get; set; }
+        public double? PageWidth { get; set; }
+        public List<PageMargins> PageMargins { get; set; } = new List<PageMargins>(); // Can have up to 2 (odd/even) or one for "both"
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PageLayout other)
+            {
+                return PageHeight == other.PageHeight &&
+                       PageWidth == other.PageWidth &&
+                       PageMargins.SequenceEqual(other.PageMargins);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(PageHeight, PageWidth, PageMargins);
+        }
+
+        public override string ToString()
+        {
+            return $"PageLayout{{PageHeight: {PageHeight}, PageWidth: {PageWidth}, PageMargins: {string.Join(", ", PageMargins)}}}";
+        }
+    }
+
+    /// <summary>
+    /// Represents scaling information in a MusicXML document.
+    /// Typically found within <defaults>.
+    /// </summary>
+    public class Scaling
+    {
+        /// <summary>
+        /// The number of millimeters per unit.
+        /// </summary>
+        public double Millimeters { get; set; }
+
+        /// <summary>
+        /// The number of tenths per unit.
+        /// </summary>
+        public double Tenths { get; set; }
+
+        public Scaling(double millimeters, double tenths)
+        {
+            Millimeters = millimeters;
+            Tenths = tenths;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Scaling other)
+            {
+                return Millimeters == other.Millimeters &&
+                       Tenths == other.Tenths;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Millimeters, Tenths);
+        }
+
+        public override string ToString()
+        {
+            return $"Scaling{{Millimeters: {Millimeters}, Tenths: {Tenths}}}";
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/Part.cs
+++ b/csharp/MusicXMLParser/Models/Part.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MusicXMLParser.Models
+{
+    /// <summary>
+    /// Represents a single part (e.g., a single instrument or voice) within a musical score.
+    /// </summary>
+    /// <remarks>
+    /// A part consists of a unique <see cref="Id"/>, an optional <see cref="Name"/>, and a list of <see cref="Measures"/>
+    /// that make up the musical content of the part.
+    /// Instances are typically created via <see cref="PartBuilder"/>.
+    /// Objects of this class are immutable once created by the builder.
+    /// </remarks>
+    public class Part
+    {
+        /// <summary>
+        /// The unique identifier for this part within the score.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// The display name of the part (e.g., "Violin I", "Piano Left Hand").
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The list of <see cref="Measure"/> objects that constitute this part.
+        /// </summary>
+        public List<Measure> Measures { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="Part"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// It is generally recommended to use <see cref="PartBuilder"/> for constructing <see cref="Part"/>
+        /// objects, especially during parsing.
+        /// </remarks>
+        public Part(string id, string name, List<Measure> measures)
+        {
+            Id = id;
+            Name = name;
+            Measures = measures;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Part other)
+            {
+                return Id == other.Id &&
+                       Name == other.Name &&
+                       Measures.SequenceEqual(other.Measures);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, Name, Measures);
+        }
+
+        public override string ToString() =>
+            $"Part{{Id: {Id}, Name: {Name}, Measures: {Measures.Count}}}";
+    }
+
+    /// <summary>
+    /// Builder for creating <see cref="Part"/> objects incrementally.
+    /// </summary>
+    /// <remarks>
+    /// This builder is useful during the parsing process for MusicXML &lt;part&gt; elements,
+    /// allowing measures to be added one by one as they are parsed.
+    /// The <see cref="Build"/> method finalizes the part construction.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var partBuilder = new PartBuilder("P1").SetName("Flute");
+    /// partBuilder.AddMeasure(firstMeasure);
+    /// partBuilder.AddMeasure(secondMeasure);
+    /// Part flutePart = partBuilder.Build();
+    /// </code>
+    /// </example>
+    public class PartBuilder
+    {
+        private readonly string _id;
+        private string _name;
+        private List<Measure> _measures = new List<Measure>();
+
+        /// <summary>
+        /// Creates a <see cref="PartBuilder"/> for a part with the given <paramref name="id"/>.
+        /// </summary>
+        public PartBuilder(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException("Part ID cannot be null or empty.", nameof(id));
+            }
+            _id = id;
+        }
+
+        /// <summary>
+        /// Sets the name of the part.
+        /// </summary>
+        public PartBuilder SetName(string name)
+        {
+            _name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets all measures for the part.
+        /// </summary>
+        public PartBuilder SetMeasures(List<Measure> measures)
+        {
+            _measures = measures ?? new List<Measure>();
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a single <see cref="Measure"/> to the part.
+        /// </summary>
+        public PartBuilder AddMeasure(Measure measure)
+        {
+            if (measure != null)
+            {
+                _measures.Add(measure);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the <see cref="Part"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method constructs the <see cref="Part"/> object from the properties set
+        /// on the builder.
+        /// </remarks>
+        public Part Build()
+        {
+            return new Part(_id, _name, _measures);
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/Pitch.cs
+++ b/csharp/MusicXMLParser/Models/Pitch.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Xml.Linq;
+using System.Linq;
+using MusicXMLParser.Exceptions; // Assuming you will create this namespace for exceptions
+using MusicXMLParser.Utils; // Assuming you will create this namespace for utils
+
+namespace MusicXMLParser.Models
+{
+    /// <summary>
+    /// Represents a musical pitch, including its step, octave, and alteration.
+    /// </summary>
+    /// <remarks>
+    /// A pitch is defined by a step (A-G), an octave (0-9), and an optional
+    /// alteration (e.g., sharp, flat). This class ensures that pitch values
+    /// conform to standard musical notation.
+    /// Objects of this class are immutable.
+    /// </remarks>
+    public class Pitch
+    {
+        /// <summary>
+        /// The musical step of the pitch, represented as a capital letter (C, D, E, F, G, A, B).
+        /// </summary>
+        public string Step { get; }
+
+        /// <summary>
+        /// The octave number (0-9) in which the pitch resides.
+        /// </summary>
+        public int Octave { get; }
+
+        /// <summary>
+        /// The chromatic alteration of the pitch.
+        /// </summary>
+        /// <remarks>
+        /// Positive values represent sharps (e.g., 1 for a single sharp),
+        /// negative values represent flats (e.g., -1 for a single flat),
+        /// and 0 or null represents no alteration. Typically ranges from -2 to 2.
+        /// </remarks>
+        public int? Alter { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="Pitch"/> instance.
+        /// </summary>
+        public Pitch(string step, int octave, int? alter = null)
+        {
+            // Basic validation can be done here if desired, though more complex validation
+            // is often handled by factory methods or dedicated validation utilities.
+            if (string.IsNullOrWhiteSpace(step))
+                throw new ArgumentException("Step cannot be null or empty.", nameof(step));
+            if (octave < ValidationUtils.MinOctave || octave > ValidationUtils.MaxOctave) // Assuming ValidationUtils will be ported
+                throw new ArgumentOutOfRangeException(nameof(octave), $"Octave must be between {ValidationUtils.MinOctave} and {ValidationUtils.MaxOctave}.");
+            if (alter.HasValue && (alter.Value < -2 || alter.Value > 2)) // Example range
+                throw new ArgumentOutOfRangeException(nameof(alter), "Alter, if specified, must be between -2 and 2.");
+
+
+            Step = step;
+            Octave = octave;
+            Alter = alter;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Pitch"/> instance from an MusicXML &lt;pitch&gt; <paramref name="element"/>.
+        /// </summary>
+        /// <remarks>
+        /// This factory parses the required &lt;step&gt; and &lt;octave&gt; elements,
+        /// and the optional &lt;alter&gt; element. It performs validation against
+        /// MusicXML rules (e.g., valid pitch steps, octave range, alter range).
+        /// Throws <see cref="MusicXmlStructureException"/> if required XML elements are missing.
+        /// Throws <see cref="MusicXmlValidationException"/> if the parsed values are invalid
+        /// according to MusicXML specifications.
+        /// </remarks>
+        /// <param name="element">The XML element representing the &lt;pitch&gt;.</param>
+        /// <param name="partId">The ID of the part, used for context in error messages.</param>
+        /// <param name="measureNumber">The number of the measure, used for context in error messages.</param>
+        public static Pitch FromXElement(XElement element, string partId, string measureNumber)
+        {
+            var line = element.Attribute("line")?.Value; // Or however line numbers are accessed
+
+            var stepElement = element.Element("step");
+            if (stepElement == null)
+            {
+                throw new MusicXmlStructureException(
+                    "Required <step> element not found in <pitch>",
+                    parentElement: "pitch",
+                    line: line,
+                    context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber } }
+                );
+            }
+            var step = stepElement.Value.Trim();
+
+            var octaveElement = element.Element("octave");
+            if (octaveElement == null)
+            {
+                throw new MusicXmlStructureException(
+                    "Required <octave> element not found in <pitch>",
+                    parentElement: "pitch",
+                    line: line,
+                    context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber } }
+                );
+            }
+            var octaveText = octaveElement.Value.Trim();
+            if (!int.TryParse(octaveText, out var octave))
+            {
+                 throw new MusicXmlValidationException(
+                    $"Invalid octave: \"{octaveText}\". Must be an integer.",
+                    rule: "pitch_octave_invalid_format",
+                    line: line,
+                    context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber }, {"parsedOctave", octaveText} }
+                );
+            }
+
+
+            var alterElement = element.Element("alter");
+            var alterText = alterElement?.Value.Trim();
+            int? alter = null;
+            if (!string.IsNullOrEmpty(alterText))
+            {
+                if (!int.TryParse(alterText, out var parsedAlter))
+                {
+                    throw new MusicXmlValidationException(
+                        $"Invalid alter value: \"{alterText}\". If present, must be an integer.",
+                        rule: "pitch_alter_invalid_format",
+                        line: line,
+                        context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber }, {"parsedAlter", alterText} }
+                    );
+                }
+                alter = parsedAlter;
+            }
+
+            // Perform validation after extracting values
+            if (!ValidationUtils.ValidPitchSteps.Contains(step))
+            {
+                throw new MusicXmlValidationException(
+                    $"Invalid pitch step: \"{step}\". Must be one of {string.Join(", ", ValidationUtils.ValidPitchSteps)}.",
+                    rule: "pitch_step_invalid",
+                    line: line,
+                    context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber }, { "parsedStep", step } }
+                );
+            }
+
+            if (octave < ValidationUtils.MinOctave || octave > ValidationUtils.MaxOctave)
+            {
+                throw new MusicXmlValidationException(
+                    $"Invalid octave: \"{octaveText}\". Must be an integer between {ValidationUtils.MinOctave} and {ValidationUtils.MaxOctave}.",
+                    rule: "pitch_octave_invalid_range",
+                    line: line,
+                    context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber }, { "parsedOctave", octaveText } }
+                );
+            }
+
+            if (alter.HasValue && (alter.Value < -2 || alter.Value > 2)) // Example range, align with ValidationUtils if it has specific constants
+            {
+                throw new MusicXmlValidationException(
+                    $"Invalid alter value: \"{alterText}\". If present, must be an integer between -2 and 2.",
+                    rule: "pitch_alter_invalid_range",
+                    line: line,
+                    context: new Dictionary<string, string> { { "part", partId }, { "measure", measureNumber }, { "parsedAlter", alterText } }
+                );
+            }
+
+            return new Pitch(step, octave, alter);
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Pitch other)
+            {
+                return Step == other.Step &&
+                       Octave == other.Octave &&
+                       Alter == other.Alter;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Step, Octave, Alter);
+        }
+
+        public override string ToString() => $"Pitch{{Step: {Step}, Octave: {Octave}, Alter: {Alter?.ToString() ?? "null"}}}";
+    }
+}

--- a/csharp/MusicXMLParser/Models/PrintObject.cs
+++ b/csharp/MusicXMLParser/Models/PrintObject.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MusicXMLParser.Models
+{
+    public class PrintObject
+    {
+        public bool NewPage { get; set; }
+        public bool NewSystem { get; set; }
+        public int? BlankPage { get; set; }
+        public string PageNumber { get; set; }
+        public PageLayout LocalPageLayout { get; set; } // Assuming PageLayout class exists
+        public SystemLayout LocalSystemLayout { get; set; } // Assuming SystemLayout class exists
+        public List<StaffLayout> LocalStaffLayouts { get; set; } = new List<StaffLayout>(); // Assuming StaffLayout class exists
+        public MeasureLayoutInfo MeasureLayout { get; set; } // Assuming MeasureLayoutInfo (or MeasureLayout) class exists
+        public MeasureNumbering MeasureNumbering { get; set; } // Assuming MeasureNumbering class exists
+
+        public PrintObject(
+            bool newPage = false,
+            bool newSystem = false,
+            int? blankPage = null,
+            string pageNumber = null,
+            PageLayout localPageLayout = null,
+            SystemLayout localSystemLayout = null,
+            List<StaffLayout> localStaffLayouts = null,
+            MeasureLayoutInfo measureLayout = null,
+            MeasureNumbering measureNumbering = null)
+        {
+            NewPage = newPage;
+            NewSystem = newSystem;
+            BlankPage = blankPage;
+            PageNumber = pageNumber;
+            LocalPageLayout = localPageLayout;
+            LocalSystemLayout = localSystemLayout;
+            LocalStaffLayouts = localStaffLayouts ?? new List<StaffLayout>();
+            MeasureLayout = measureLayout;
+            MeasureNumbering = measureNumbering;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PrintObject other)
+            {
+                return NewPage == other.NewPage &&
+                       NewSystem == other.NewSystem &&
+                       BlankPage == other.BlankPage &&
+                       PageNumber == other.PageNumber &&
+                       object.Equals(LocalPageLayout, other.LocalPageLayout) &&
+                       object.Equals(LocalSystemLayout, other.LocalSystemLayout) &&
+                       LocalStaffLayouts.SequenceEqual(other.LocalStaffLayouts) &&
+                       object.Equals(MeasureLayout, other.MeasureLayout) &&
+                       object.Equals(MeasureNumbering, other.MeasureNumbering);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(NewPage);
+            hashCode.Add(NewSystem);
+            hashCode.Add(BlankPage);
+            hashCode.Add(PageNumber);
+            hashCode.Add(LocalPageLayout);
+            hashCode.Add(LocalSystemLayout);
+            // For lists, a common approach is to combine hash codes of elements or use a more sophisticated method if order matters.
+            // Here's a simple way if order and content matter:
+            if (LocalStaffLayouts != null)
+            {
+                foreach (var item in LocalStaffLayouts)
+                {
+                    hashCode.Add(item);
+                }
+            }
+            hashCode.Add(MeasureLayout);
+            hashCode.Add(MeasureNumbering);
+            return hashCode.ToHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"PrintObject{{NewPage: {NewPage}, NewSystem: {NewSystem}, BlankPage: {BlankPage?.ToString() ?? "null"}, PageNumber: {PageNumber ?? "null"}, LocalPageLayout: {LocalPageLayout}, LocalSystemLayout: {LocalSystemLayout}, LocalStaffLayouts: [{string.Join(", ", LocalStaffLayouts)}], MeasureLayout: {MeasureLayout}, MeasureNumbering: {MeasureNumbering}}}";
+        }
+    }
+
+    // Assuming MeasureNumbering is a simple class or enum.
+    // If it's complex, it should be in its own file.
+    // For now, let's assume it's part of MeasureLayoutInfo or a simple enum-like structure.
+    // Example:
+    // public enum MeasureNumberingValue { None, Measure, System }
+    // public class MeasureNumbering
+    // {
+    //     public MeasureNumberingValue Value { get; set; }
+    //     // Add other properties if needed from the Dart model
+    // }
+    // NOTE: The Dart model 'measure_layout_info.dart' defines MeasureNumbering.
+    // It will be ported later. For now, this placeholder might be okay,
+    // or PrintObject can temporarily use a more generic type if MeasureNumbering is complex.
+}

--- a/csharp/MusicXMLParser/Models/Score.cs
+++ b/csharp/MusicXMLParser/Models/Score.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MusicXMLParser.Models
+{
+    /// <summary>
+    /// Represents a complete MusicXML score document.
+    /// </summary>
+    /// <remarks>
+    /// This is the top-level object for a parsed MusicXML file. It contains
+    /// metadata such as <see cref="Version"/>, <see cref="Work"/> information, <see cref="Identification"/> details,
+    /// and a list of <see cref="Parts"/> that make up the score. It also holds default
+    /// layout information (<see cref="PageLayout"/>, <see cref="DefaultSystemLayout"/>, <see cref="DefaultStaffLayouts"/>),
+    /// <see cref="Scaling"/>, and <see cref="Appearance"/> settings.
+    /// Instances are typically created via <see cref="ScoreBuilder"/>.
+    /// Objects of this class are immutable once created by the builder.
+    /// </remarks>
+    public class Score
+    {
+        /// <summary>
+        /// The version of the MusicXML format used for the score (e.g., "3.1", "4.0").
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// Information about the musical work itself (e.g., title).
+        /// </summary>
+        public Work Work { get; } // Assuming Work class will be ported
+
+        /// <summary>
+        /// Identification metadata for the score (e.g., composer, rights).
+        /// </summary>
+        public Identification Identification { get; } // Assuming Identification class exists
+
+        /// <summary>
+        /// The list of <see cref="Part"/> objects that constitute the score.
+        /// </summary>
+        public List<Part> Parts { get; }
+
+        /// <summary>
+        /// Default page layout settings for the score.
+        /// </summary>
+        public PageLayout PageLayout { get; } // Assuming PageLayout class exists
+
+        /// <summary>
+        /// Default system layout settings (e.g., margins, distances between systems).
+        /// </summary>
+        public SystemLayout DefaultSystemLayout { get; } // Assuming SystemLayout placeholder exists
+
+        /// <summary>
+        /// List of default staff layout settings (e.g., staff distances).
+        /// </summary>
+        public List<StaffLayout> DefaultStaffLayouts { get; } // Assuming StaffLayout placeholder exists
+
+        /// <summary>
+        /// Scaling information used for rendering (e.g., millimeters per tenth).
+        /// </summary>
+        public Scaling Scaling { get; } // Assuming Scaling class exists (part of PageLayout.cs)
+
+        /// <summary>
+        /// Default appearance settings (e.g., line widths, note sizes).
+        /// </summary>
+        public Appearance Appearance { get; } // Assuming Appearance class exists
+
+        /// <summary>
+        /// The primary title of the score.
+        /// Often also found within <see cref="Work"/> or <see cref="Identification"/> elements.
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        /// The primary composer of the score.
+        /// Often also found within <see cref="Identification"/> elements.
+        /// </summary>
+        public string Composer { get; }
+
+        /// <summary>
+        /// A list of <see cref="Credit"/> entries for the score (e.g., copyright, arranger).
+        /// </summary>
+        public List<Credit> Credits { get; } // Assuming Credit class exists
+
+        /// <summary>
+        /// Creates a new <see cref="Score"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// It is generally recommended to use <see cref="ScoreBuilder"/> for constructing <see cref="Score"/>
+        /// objects, as it simplifies the process of incrementally adding properties
+        /// during parsing.
+        /// </remarks>
+        public Score(
+            string version,
+            List<Part> parts,
+            Work work = null,
+            Identification identification = null,
+            PageLayout pageLayout = null,
+            SystemLayout defaultSystemLayout = null,
+            List<StaffLayout> defaultStaffLayouts = null,
+            Scaling scaling = null,
+            Appearance appearance = null,
+            string title = null,
+            string composer = null,
+            List<Credit> credits = null)
+        {
+            if (string.IsNullOrEmpty(version))
+                throw new ArgumentException("Version cannot be null or empty.", nameof(version));
+
+            Version = version;
+            Parts = parts ?? throw new ArgumentNullException(nameof(parts));
+            Work = work;
+            Identification = identification;
+            PageLayout = pageLayout;
+            DefaultSystemLayout = defaultSystemLayout;
+            DefaultStaffLayouts = defaultStaffLayouts ?? new List<StaffLayout>();
+            Scaling = scaling;
+            Appearance = appearance;
+            Title = title;
+            Composer = composer;
+            Credits = credits ?? new List<Credit>();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Score other)
+            {
+                return Version == other.Version &&
+                       object.Equals(Work, other.Work) &&
+                       object.Equals(Identification, other.Identification) &&
+                       Parts.SequenceEqual(other.Parts) &&
+                       object.Equals(PageLayout, other.PageLayout) &&
+                       object.Equals(DefaultSystemLayout, other.DefaultSystemLayout) &&
+                       DefaultStaffLayouts.SequenceEqual(other.DefaultStaffLayouts) &&
+                       object.Equals(Scaling, other.Scaling) &&
+                       object.Equals(Appearance, other.Appearance) &&
+                       Title == other.Title &&
+                       Composer == other.Composer &&
+                       Credits.SequenceEqual(other.Credits);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(Version);
+            hashCode.Add(Work);
+            hashCode.Add(Identification);
+            Parts?.ForEach(p => hashCode.Add(p)); // Simplified; consider a more robust list hashing
+            hashCode.Add(PageLayout);
+            hashCode.Add(DefaultSystemLayout);
+            DefaultStaffLayouts?.ForEach(s => hashCode.Add(s)); // Simplified
+            hashCode.Add(Scaling);
+            hashCode.Add(Appearance);
+            hashCode.Add(Title);
+            hashCode.Add(Composer);
+            Credits?.ForEach(c => hashCode.Add(c)); // Simplified
+            return hashCode.ToHashCode();
+        }
+
+        public override string ToString()
+        {
+            var buffer = new StringBuilder($"Score{{Version: {Version}");
+            if (!string.IsNullOrEmpty(Title)) buffer.Append($", Title: {Title}");
+            if (!string.IsNullOrEmpty(Composer)) buffer.Append($", Composer: {Composer}");
+            if (Work != null) buffer.Append($", Work: {Work}");
+            if (Identification != null) buffer.Append($", Identification: {Identification}");
+            buffer.Append($", Parts: {Parts?.Count ?? 0}");
+            if (PageLayout != null) buffer.Append($", DefaultPageLayout: {PageLayout}");
+            if (DefaultSystemLayout != null) buffer.Append($", DefaultSystemLayout: {DefaultSystemLayout}");
+            if (DefaultStaffLayouts != null && DefaultStaffLayouts.Any()) buffer.Append($", DefaultStaffLayouts: [{string.Join(", ", DefaultStaffLayouts)}]");
+            if (Scaling != null) buffer.Append($", Scaling: {Scaling}");
+            if (Appearance != null) buffer.Append($", Appearance: {Appearance}");
+            if (Credits != null && Credits.Any()) buffer.Append($", Credits: {Credits.Count}");
+            buffer.Append("}");
+            return buffer.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Builder for creating <see cref="Score"/> objects incrementally.
+    /// </summary>
+    public class ScoreBuilder
+    {
+        private string _version = "3.0"; // Default version
+        private Work _work;
+        private Identification _identification;
+        private List<Part> _parts = new List<Part>();
+        private PageLayout _pageLayout;
+        private SystemLayout _defaultSystemLayout;
+        private List<StaffLayout> _defaultStaffLayouts = new List<StaffLayout>();
+        private Scaling _scaling;
+        private Appearance _appearance;
+        private string _title;
+        private string _composer;
+        private List<Credit> _credits = new List<Credit>();
+
+        public ScoreBuilder(string version = "3.0")
+        {
+            SetVersion(version);
+        }
+
+        public ScoreBuilder SetVersion(string version)
+        {
+            _version = !string.IsNullOrEmpty(version) ? version : "3.0";
+            return this;
+        }
+
+        public ScoreBuilder SetWork(Work work) { _work = work; return this; }
+        public ScoreBuilder SetIdentification(Identification identification) { _identification = identification; return this; }
+        public ScoreBuilder SetParts(List<Part> parts) { _parts = parts ?? new List<Part>(); return this; }
+        public ScoreBuilder AddPart(Part part) { if (part != null) _parts.Add(part); return this; }
+        public ScoreBuilder SetPageLayout(PageLayout pageLayout) { _pageLayout = pageLayout; return this; }
+        public ScoreBuilder SetDefaultSystemLayout(SystemLayout systemLayout) { _defaultSystemLayout = systemLayout; return this; }
+        public ScoreBuilder setDefaultStaffLayouts(List<StaffLayout> staffLayouts) { _defaultStaffLayouts = staffLayouts ?? new List<StaffLayout>(); return this; }
+        public ScoreBuilder AddDefaultStaffLayout(StaffLayout staffLayout) { if (staffLayout != null) _defaultStaffLayouts.Add(staffLayout); return this; }
+        public ScoreBuilder SetScaling(Scaling scaling) { _scaling = scaling; return this; }
+        public ScoreBuilder SetAppearance(Appearance appearance) { _appearance = appearance; return this; }
+        public ScoreBuilder SetTitle(string title) { _title = title; return this; }
+        public ScoreBuilder SetComposer(string composer) { _composer = composer; return this; }
+        public ScoreBuilder SetCredits(List<Credit> credits) { _credits = credits ?? new List<Credit>(); return this; }
+        public ScoreBuilder AddCredit(Credit credit) { if (credit != null) _credits.Add(credit); return this; }
+
+        public Score Build()
+        {
+            return new Score(
+                _version,
+                _parts,
+                _work,
+                _identification,
+                _pageLayout,
+                _defaultSystemLayout,
+                _defaultStaffLayouts,
+                _scaling,
+                _appearance,
+                _title,
+                _composer,
+                _credits
+            );
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/Slur.cs
+++ b/csharp/MusicXMLParser/Models/Slur.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Text;
+
+namespace MusicXMLParser.Models
+{
+    /// <summary>
+    /// Represents a slur mark attached to a note.
+    /// </summary>
+    public class Slur
+    {
+        /// <summary>
+        /// The type of slur (e.g., "start", "stop", "continue").
+        /// </summary>
+        public string Type { get; } // Consider an enum SlurType in the future
+
+        /// <summary>
+        /// The slur number, used for matching slurs that span multiple notes.
+        /// Defaults to 1 if not specified in the MusicXML.
+        /// </summary>
+        public int Number { get; }
+
+        /// <summary>
+        /// The placement of the slur relative to the note (e.g., "above", "below").
+        /// Optional.
+        /// </summary>
+        public string Placement { get; } // Consider an enum Placement in the future
+
+        // Other common attributes like orientation, bezier points can be added later.
+
+        /// <summary>
+        /// Creates a new <see cref="Slur"/> instance.
+        /// </summary>
+        public Slur(string type, int number = 1, string placement = null)
+        {
+            if (string.IsNullOrEmpty(type))
+                throw new ArgumentException("Slur type cannot be null or empty.", nameof(type));
+
+            Type = type;
+            Number = number;
+            Placement = placement;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Slur other)
+            {
+                return Type == other.Type &&
+                       Number == other.Number &&
+                       Placement == other.Placement;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, Number, Placement);
+        }
+
+        public override string ToString()
+        {
+            var parts = new List<string>
+            {
+                $"Type: {Type}",
+                $"Number: {Number}"
+            };
+            if (!string.IsNullOrEmpty(Placement))
+            {
+                parts.Add($"Placement: {Placement}");
+            }
+            return $"Slur{{{string.Join(", ", parts)}}}";
+        }
+    }
+
+    // Future considerations:
+    // public enum SlurType { Start, Stop, Continue }
+    // public enum Placement { Above, Below }
+}

--- a/csharp/MusicXMLParser/Models/StaffLayout.cs
+++ b/csharp/MusicXMLParser/Models/StaffLayout.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace MusicXMLParser.Models
+{
+    public class StaffLayout
+    {
+        /// <summary>
+        /// Staff number this layout applies to (default 1 if not present in XML attribute).
+        /// </summary>
+        public int StaffNumber { get; }
+
+        /// <summary>
+        /// Distance from the previous staff.
+        /// </summary>
+        public double? StaffDistance { get; }
+
+        public StaffLayout(int staffNumber, double? staffDistance = null)
+        {
+            StaffNumber = staffNumber;
+            StaffDistance = staffDistance;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is StaffLayout other)
+            {
+                return StaffNumber == other.StaffNumber &&
+                       StaffDistance == other.StaffDistance;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(StaffNumber, StaffDistance);
+        }
+
+        public override string ToString()
+        {
+            return $"StaffLayout{{StaffNumber: {StaffNumber}, StaffDistance: {StaffDistance?.ToString() ?? "null"}}}";
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/SystemLayout.cs
+++ b/csharp/MusicXMLParser/Models/SystemLayout.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace MusicXMLParser.Models
+{
+    public class SystemMargins
+    {
+        public double? LeftMargin { get; set; }
+        public double? RightMargin { get; set; }
+
+        public SystemMargins(double? leftMargin = null, double? rightMargin = null)
+        {
+            LeftMargin = leftMargin;
+            RightMargin = rightMargin;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SystemMargins other)
+            {
+                return LeftMargin == other.LeftMargin &&
+                       RightMargin == other.RightMargin;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(LeftMargin, RightMargin);
+        }
+
+        public override string ToString()
+        {
+            return $"SystemMargins{{LeftMargin: {LeftMargin?.ToString() ?? "null"}, RightMargin: {RightMargin?.ToString() ?? "null"}}}";
+        }
+    }
+
+    public class SystemDividers
+    {
+        public bool LeftDivider { get; set; }
+        public bool RightDivider { get; set; }
+
+        public SystemDividers(bool leftDivider = false, bool rightDivider = false)
+        {
+            LeftDivider = leftDivider;
+            RightDivider = rightDivider;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SystemDividers other)
+            {
+                return LeftDivider == other.LeftDivider &&
+                       RightDivider == other.RightDivider;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(LeftDivider, RightDivider);
+        }
+
+        public override string ToString()
+        {
+            return $"SystemDividers{{LeftDivider: {LeftDivider}, RightDivider: {RightDivider}}}";
+        }
+    }
+
+    public class SystemLayout
+    {
+        public SystemMargins SystemMargins { get; set; }
+        public double? SystemDistance { get; set; }
+        public double? TopSystemDistance { get; set; }
+        public SystemDividers SystemDividers { get; set; }
+
+        public SystemLayout(
+            SystemMargins systemMargins = null,
+            double? systemDistance = null,
+            double? topSystemDistance = null,
+            SystemDividers systemDividers = null)
+        {
+            SystemMargins = systemMargins;
+            SystemDistance = systemDistance;
+            TopSystemDistance = topSystemDistance;
+            SystemDividers = systemDividers;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SystemLayout other)
+            {
+                return object.Equals(SystemMargins, other.SystemMargins) &&
+                       SystemDistance == other.SystemDistance &&
+                       TopSystemDistance == other.TopSystemDistance &&
+                       object.Equals(SystemDividers, other.SystemDividers);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(SystemMargins, SystemDistance, TopSystemDistance, SystemDividers);
+        }
+
+        public override string ToString()
+        {
+            return $"SystemLayout{{SystemMargins: {SystemMargins}, SystemDistance: {SystemDistance?.ToString() ?? "null"}, TopSystemDistance: {TopSystemDistance?.ToString() ?? "null"}, SystemDividers: {SystemDividers}}}";
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/Tie.cs
+++ b/csharp/MusicXMLParser/Models/Tie.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace MusicXMLParser.Models
+{
+    /// <summary>
+    /// Represents a tie mark connecting notes of the same pitch.
+    /// </summary>
+    public class Tie
+    {
+        /// <summary>
+        /// The type of tie (e.g., "start", "stop").
+        /// MusicXML also allows "continue" but it's less common for basic ties.
+        /// </summary>
+        public string Type { get; }
+
+        /// <summary>
+        /// The placement of the tie relative to the note (e.g., "above", "below").
+        /// Optional.
+        /// </summary>
+        public string Placement { get; } // Consider an enum Placement in the future
+
+        /// <summary>
+        /// Creates a new <see cref="Tie"/> instance.
+        /// </summary>
+        public Tie(string type, string placement = null)
+        {
+            if (string.IsNullOrEmpty(type))
+                throw new ArgumentException("Tie type cannot be null or empty.", nameof(type));
+
+            Type = type;
+            Placement = placement;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Tie other)
+            {
+                return Type == other.Type &&
+                       Placement == other.Placement;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, Placement);
+        }
+
+        public override string ToString()
+        {
+            var parts = new List<string> { $"Type: {Type}" };
+            if (!string.IsNullOrEmpty(Placement))
+            {
+                parts.Add($"Placement: {Placement}");
+            }
+            return $"Tie{{{string.Join(", ", parts)}}}";
+        }
+    }
+
+    // Future considerations:
+    // public enum TieType { Start, Stop, Continue }
+    // public enum Placement { Above, Below } // (already considered for Slur)
+}

--- a/csharp/MusicXMLParser/Models/TimeModification.cs
+++ b/csharp/MusicXMLParser/Models/TimeModification.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using MusicXMLParser.Exceptions; // Assuming exceptions are in this namespace
+
+namespace MusicXMLParser.Models
+{
+    /// <summary>
+    /// Represents a time modification, such as a tuplet.
+    /// </summary>
+    public class TimeModification
+    {
+        /// <summary>
+        /// The number of actual notes in the tuplet (e.g., 3 for a triplet).
+        /// </summary>
+        public int ActualNotes { get; }
+
+        /// <summary>
+        /// The number of normal notes of the same type that would normally
+        /// occupy the same duration (e.g., 2 for a triplet of eighths).
+        /// </summary>
+        public int NormalNotes { get; }
+
+        /// <summary>
+        /// The note type of the normal notes (e.g., "eighth", "quarter").
+        /// Optional in MusicXML.
+        /// </summary>
+        public string NormalType { get; }
+
+        /// <summary>
+        /// The number of dots on the normal notes, if specified.
+        /// This represents the count of &lt;normal-dot/&gt; elements.
+        /// Null if &lt;normal-dot&gt; elements are not present.
+        /// </summary>
+        public int? NormalDotCount { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="TimeModification"/> instance.
+        /// </summary>
+        public TimeModification(
+            int actualNotes,
+            int normalNotes,
+            string normalType = null,
+            int? normalDotCount = null)
+        {
+            if (actualNotes <= 0)
+                throw new ArgumentOutOfRangeException(nameof(actualNotes), "ActualNotes must be positive.");
+            if (normalNotes <= 0)
+                throw new ArgumentOutOfRangeException(nameof(normalNotes), "NormalNotes must be positive.");
+            if (normalDotCount.HasValue && normalDotCount.Value < 0)
+                throw new ArgumentOutOfRangeException(nameof(normalDotCount), "NormalDotCount cannot be negative if specified.");
+
+            ActualNotes = actualNotes;
+            NormalNotes = normalNotes;
+            NormalType = normalType;
+            NormalDotCount = normalDotCount;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TimeModification"/> instance with validation using MusicXML specific exceptions.
+        /// </summary>
+        public static TimeModification CreateValidated(
+            int actualNotes,
+            int normalNotes,
+            string normalType = null,
+            int? normalDotCount = null,
+            string line = null, // For error reporting
+            Dictionary<string, string> context = null) // For error reporting
+        {
+            if (actualNotes <= 0)
+            {
+                var errorContext = new Dictionary<string, string>(context ?? new Dictionary<string, string>());
+                errorContext["actualNotes"] = actualNotes.ToString();
+                throw new MusicXmlValidationException(
+                    $"TimeModification actualNotes must be positive, got {actualNotes}",
+                    rule: "time_modification_actual_notes_positive",
+                    line: line,
+                    context: errorContext
+                );
+            }
+            if (normalNotes <= 0)
+            {
+                var errorContext = new Dictionary<string, string>(context ?? new Dictionary<string, string>());
+                errorContext["normalNotes"] = normalNotes.ToString();
+                throw new MusicXmlValidationException(
+                    $"TimeModification normalNotes must be positive, got {normalNotes}",
+                    rule: "time_modification_normal_notes_positive",
+                    line: line,
+                    context: errorContext
+                );
+            }
+            if (normalDotCount.HasValue && normalDotCount.Value < 0)
+            {
+                var errorContext = new Dictionary<string, string>(context ?? new Dictionary<string, string>());
+                errorContext["normalDotCount"] = normalDotCount.Value.ToString();
+                throw new MusicXmlValidationException(
+                    $"TimeModification normalDotCount cannot be negative if specified, got {normalDotCount}",
+                    rule: "time_modification_normal_dot_count_non_negative",
+                    line: line,
+                    context: errorContext
+                );
+            }
+
+            return new TimeModification(actualNotes, normalNotes, normalType, normalDotCount);
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TimeModification other)
+            {
+                return ActualNotes == other.ActualNotes &&
+                       NormalNotes == other.NormalNotes &&
+                       NormalType == other.NormalType &&
+                       NormalDotCount == other.NormalDotCount;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(ActualNotes, NormalNotes, NormalType, NormalDotCount);
+        }
+
+        public override string ToString()
+        {
+            var parts = new List<string>
+            {
+                $"ActualNotes: {ActualNotes}",
+                $"NormalNotes: {NormalNotes}"
+            };
+            if (!string.IsNullOrEmpty(NormalType))
+            {
+                parts.Add($"NormalType: {NormalType}");
+            }
+            if (NormalDotCount.HasValue)
+            {
+                parts.Add($"NormalDotCount: {NormalDotCount.Value}");
+            }
+            return $"TimeModification{{{string.Join(", ", parts)}}}";
+        }
+    }
+}

--- a/csharp/MusicXMLParser/Models/Work.cs
+++ b/csharp/MusicXMLParser/Models/Work.cs
@@ -1,0 +1,7 @@
+namespace MusicXMLParser.Models
+{
+    // Placeholder class
+    public class Work
+    {
+    }
+}

--- a/csharp/MusicXMLParser/Utils/ValidationUtils.cs
+++ b/csharp/MusicXMLParser/Utils/ValidationUtils.cs
@@ -1,0 +1,393 @@
+using MusicXMLParser.Models; // Assuming your models are in this namespace
+using MusicXMLParser.Exceptions; // Assuming your exceptions are in this namespace
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MusicXMLParser.Utils
+{
+    /// <summary>
+    /// Utility class containing validation rules for MusicXML elements.
+    /// </summary>
+    /// <remarks>
+    /// This class provides static methods for validating various musical elements
+    /// to ensure they conform to musical theory and MusicXML specifications.
+    /// </remarks>
+    public static class ValidationUtils
+    {
+        /// <summary>
+        /// Valid pitch steps in musical notation.
+        /// </summary>
+        public static readonly ISet<string> ValidPitchSteps = new HashSet<string> { "C", "D", "E", "F", "G", "A", "B" };
+
+        /// <summary>
+        /// Minimum valid octave number.
+        /// </summary>
+        public const int MinOctave = 0;
+
+        /// <summary>
+        /// Maximum valid octave number.
+        /// </summary>
+        public const int MaxOctave = 9;
+
+        /// <summary>
+        /// Minimum valid key signature fifths value.
+        /// </summary>
+        public const int MinFifths = -7;
+
+        /// <summary>
+        /// Maximum valid key signature fifths value.
+        /// </summary>
+        public const int MaxFifths = 7;
+
+        /// <summary>
+        /// Valid key signature modes.
+        /// </summary>
+        public static readonly ISet<string> ValidModes = new HashSet<string>
+        {
+            "major", "minor", "dorian", "phrygian", "lydian",
+            "mixolydian", "aeolian", "ionian", "locrian"
+        };
+
+        /// <summary>
+        /// Validates a pitch object.
+        /// </summary>
+        /// <remarks>
+        /// Checks that the pitch step is valid (C, D, E, F, G, A, B) and
+        /// the octave is within the valid range (0-9).
+        /// Throws <see cref="MusicXmlValidationException"/> if validation fails.
+        /// </remarks>
+        public static void ValidatePitch(Pitch pitch, string line = null, Dictionary<string, string> context = null)
+        {
+            if (pitch == null) throw new ArgumentNullException(nameof(pitch));
+
+            // Validate step
+            if (!ValidPitchSteps.Contains(pitch.Step))
+            {
+                throw new MusicXmlValidationException(
+                    $"Invalid pitch step \"{pitch.Step}\". Expected one of: {string.Join(", ", ValidPitchSteps)}",
+                    rule: "pitch_step_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "step", pitch.Step },
+                        { "octave", pitch.Octave.ToString() },
+                        { "alter", pitch.Alter?.ToString() }
+                    }, context)
+                );
+            }
+
+            // Validate octave
+            if (pitch.Octave < MinOctave || pitch.Octave > MaxOctave)
+            {
+                throw new MusicXmlValidationException(
+                    $"Pitch octave {pitch.Octave} is out of valid range ({MinOctave}-{MaxOctave})",
+                    rule: "pitch_octave_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "step", pitch.Step },
+                        { "octave", pitch.Octave.ToString() },
+                        { "alter", pitch.Alter?.ToString() }
+                    }, context)
+                );
+            }
+
+            // Validate alter (alteration should be reasonable)
+            if (pitch.Alter.HasValue && (pitch.Alter.Value < -2 || pitch.Alter.Value > 2))
+            {
+                throw new MusicXmlValidationException(
+                    $"Pitch alteration {pitch.Alter} is out of reasonable range (-2 to +2)",
+                    rule: "pitch_alter_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "step", pitch.Step },
+                        { "octave", pitch.Octave.ToString() },
+                        { "alter", pitch.Alter?.ToString() }
+                    }, context)
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates a duration object.
+        /// </summary>
+        /// <remarks>
+        /// Checks that the duration value is positive.
+        /// Throws <see cref="MusicXmlValidationException"/> if validation fails.
+        /// </remarks>
+        public static void ValidateDuration(Duration duration, string line = null, Dictionary<string, string> context = null)
+        {
+            if (duration == null) throw new ArgumentNullException(nameof(duration));
+
+            if (duration.Value <= 0)
+            {
+                throw new MusicXmlValidationException(
+                    $"Duration value must be positive, got {duration.Value}",
+                    rule: "duration_positive_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "value", duration.Value.ToString() },
+                        { "divisions", duration.Divisions.ToString() }
+                    }, context)
+                );
+            }
+
+            if (duration.Divisions <= 0)
+            {
+                throw new MusicXmlValidationException(
+                    $"Duration divisions must be positive, got {duration.Divisions}",
+                    rule: "duration_divisions_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "value", duration.Value.ToString() },
+                        { "divisions", duration.Divisions.ToString() }
+                    }, context)
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates a key signature object.
+        /// </summary>
+        /// <remarks>
+        /// Checks that the fifths value is within the valid range (-7 to +7)
+        /// and the mode is valid if specified.
+        /// Throws <see cref="MusicXmlValidationException"/> if validation fails.
+        /// </remarks>
+        public static void ValidateKeySignature(KeySignature keySignature, string line = null, Dictionary<string, string> context = null)
+        {
+            if (keySignature == null) throw new ArgumentNullException(nameof(keySignature));
+
+            // Validate fifths
+            if (keySignature.Fifths < MinFifths || keySignature.Fifths > MaxFifths)
+            {
+                throw new MusicXmlValidationException(
+                    $"Key signature fifths {keySignature.Fifths} is out of valid range ({MinFifths} to {MaxFifths})",
+                    rule: "key_signature_fifths_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "fifths", keySignature.Fifths.ToString() },
+                        { "mode", keySignature.Mode }
+                    }, context)
+                );
+            }
+
+            // Validate mode if specified
+            if (!string.IsNullOrEmpty(keySignature.Mode) && !ValidModes.Contains(keySignature.Mode.ToLower()))
+            {
+                throw new MusicXmlValidationException(
+                    $"Invalid key signature mode \"{keySignature.Mode}\". Expected one of: {string.Join(", ", ValidModes)}",
+                    rule: "key_signature_mode_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "fifths", keySignature.Fifths.ToString() },
+                        { "mode", keySignature.Mode }
+                    }, context)
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates a time signature object.
+        /// </summary>
+        /// <remarks>
+        /// Checks that beats is positive and beat type is a power of 2.
+        /// Throws <see cref="MusicXmlValidationException"/> if validation fails.
+        /// </remarks>
+        public static void ValidateTimeSignature(TimeSignature timeSignature, string line = null, Dictionary<string, string> context = null)
+        {
+            if (timeSignature == null) throw new ArgumentNullException(nameof(timeSignature));
+
+            // Validate beats
+            if (timeSignature.Beats <= 0)
+            {
+                throw new MusicXmlValidationException(
+                    $"Time signature beats must be positive, got {timeSignature.Beats}",
+                    rule: "time_signature_beats_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "beats", timeSignature.Beats.ToString() },
+                        { "beatType", timeSignature.BeatType.ToString() }
+                    }, context)
+                );
+            }
+
+            // Validate beat type (should be a power of 2)
+            if (timeSignature.BeatType <= 0 || !IsPowerOfTwo(timeSignature.BeatType))
+            {
+                throw new MusicXmlValidationException(
+                    $"Time signature beat type must be a positive power of 2, got {timeSignature.BeatType}",
+                    rule: "time_signature_beat_type_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "beats", timeSignature.Beats.ToString() },
+                        { "beatType", timeSignature.BeatType.ToString() }
+                    }, context)
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates a note object.
+        /// </summary>
+        /// <remarks>
+        /// Performs comprehensive validation including pitch validation for non-rest notes
+        /// and duration validation.
+        /// Throws <see cref="MusicXmlValidationException"/> if validation fails.
+        /// </remarks>
+        public static void ValidateNote(Note note, string line = null, Dictionary<string, string> context = null)
+        {
+            if (note == null) throw new ArgumentNullException(nameof(note));
+
+            // Validate duration if present
+            if (note.Duration != null) // Assuming Duration is a class/struct and can be null
+            {
+                ValidateDuration(note.Duration, line: line, context: context);
+            }
+
+            // Validate pitch if not a rest
+            if (!note.IsRest && note.Pitch != null) // Assuming Pitch is a class/struct and can be null
+            {
+                ValidatePitch(note.Pitch, line: line, context: context);
+            }
+
+            // Validate voice (should be positive if specified)
+            if (note.Voice.HasValue && note.Voice.Value <= 0)
+            {
+                throw new MusicXmlValidationException(
+                    $"Note voice must be positive, got {note.Voice}",
+                    rule: "note_voice_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "voice", note.Voice?.ToString() },
+                        { "isRest", note.IsRest.ToString() }
+                    }, context)
+                );
+            }
+
+            // Validate that rests don't have pitches
+            if (note.IsRest && note.Pitch != null)
+            {
+                throw new MusicXmlValidationException(
+                    "Rest notes should not have pitch information",
+                    rule: "rest_no_pitch_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "isRest", note.IsRest.ToString() },
+                        { "hasPitch", (note.Pitch != null).ToString() }
+                    }, context)
+                );
+            }
+
+            // Validate that non-rest notes have pitches (unless it's a special case like unpitched percussion)
+            // This might need refinement based on how unpitched notes are represented.
+            if (!note.IsRest && note.Pitch == null && !note.IsUnpitched) // Assuming an IsUnpitched property or similar
+            {
+                throw new MusicXmlValidationException(
+                    "Non-rest, pitched notes must have pitch information",
+                    rule: "note_pitch_required_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "isRest", note.IsRest.ToString() },
+                        { "hasPitch", (note.Pitch != null).ToString() },
+                        {"isUnpitched", note.IsUnpitched.ToString()}
+                    }, context)
+                );
+            }
+        }
+
+        // Placeholder for IsUnpitched if not directly on Note model
+        // Example: Adapt based on your Note model structure
+        // private static bool IsNoteUnpitched(Note note) => note.Unpitched != null;
+
+
+        /// <summary>
+        /// Validates that measure duration matches the time signature.
+        /// </summary>
+        /// <remarks>
+        /// This is a simplified validation - a complete implementation would need
+        /// to handle complex rhythmic patterns, grace notes, etc.
+        /// Throws <see cref="MusicXmlValidationException"/> if validation fails.
+        /// </remarks>
+        public static void ValidateMeasureDuration(
+            List<Note> notes,
+            TimeSignature timeSignature,
+            int? divisions,
+            string line = null,
+            Dictionary<string, string> context = null)
+        {
+            if (notes == null) throw new ArgumentNullException(nameof(notes));
+            if (timeSignature == null || !divisions.HasValue)
+            {
+                return; // Can't validate without time signature and divisions
+            }
+
+            // Calculate expected measure duration in divisions
+            var expectedDuration =
+                (timeSignature.Beats * divisions.Value * 4) / timeSignature.BeatType;
+
+            // Calculate actual duration from notes (skip notes without duration)
+            long actualDuration = 0; // Use long to avoid overflow if many notes
+            foreach (var note in notes)
+            {
+                if (note.Duration != null)
+                {
+                    actualDuration += note.Duration.Value;
+                }
+            }
+
+            if (actualDuration != expectedDuration)
+            {
+                throw new MusicXmlValidationException(
+                    $"Measure duration ({actualDuration}) does not match time signature expectation ({expectedDuration})",
+                    rule: "measure_duration_validation",
+                    line: line,
+                    context: MergeContext(new Dictionary<string, string>
+                    {
+                        { "actualDuration", actualDuration.ToString() },
+                        { "expectedDuration", expectedDuration.ToString() },
+                        { "timeSignature", $"{timeSignature.Beats}/{timeSignature.BeatType}" },
+                        { "divisions", divisions.Value.ToString() },
+                        { "noteCount", notes.Count.ToString() }
+                    }, context)
+                );
+            }
+        }
+
+
+        /// <summary>
+        /// Helper method to check if a number is a power of 2.
+        /// </summary>
+        private static bool IsPowerOfTwo(int n)
+        {
+            return n > 0 && (n & (n - 1)) == 0;
+        }
+
+        /// <summary>
+        /// Helper method to merge base context with additional context.
+        /// </summary>
+        private static Dictionary<string, string> MergeContext(Dictionary<string, string> baseContext, Dictionary<string, string> additionalContext)
+        {
+            if (additionalContext == null) return baseContext;
+            if (baseContext == null) return additionalContext;
+
+            var merged = new Dictionary<string, string>(baseContext);
+            foreach (var item in additionalContext)
+            {
+                merged[item.Key] = item.Value; // Overwrites if key exists, which is typical for context override
+            }
+            return merged;
+        }
+    }
+}


### PR DESCRIPTION


This commit ports several Dart model classes to their C# equivalents in the `csharp/MusicXMLParser/Models` directory.

Ported files:
- PageLayout.cs (from page_layout.dart)
- Part.cs (from part.dart)
- Pitch.cs (from pitch.dart)
- PrintObject.cs (from print_object.dart)
- Score.cs (from score.dart)
- Slur.cs (from slur.dart)
- StaffLayout.cs (from staff_layout.dart, replacing placeholder)
- SystemLayout.cs (from system_layout.dart, replacing placeholder)